### PR TITLE
feat: login/logout endpoints with session creation

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -21,6 +21,7 @@
   "RmqQueueMailName": "sendmail",
   "RmqExchangeName": "mail",
   "RmqExchangeKind": "direct",
+  "SessionTTLDays": 30,
   "RateLimit": {
     "IP": {
       "LoginMaxAttempts": 5,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,6 +88,8 @@ func main() {
 	})
 
 	r.POST("/auth/register", handler.Register(pgPool, rmqConn, cfg))
+	r.POST("/auth/login", handler.Login(pgPool, cfg))
+	r.POST("/auth/logout", handler.Logout(pgPool))
 
 	addr := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
 	log.Printf("starting server on %s", addr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	RmqExchangeName       string    `json:"RmqExchangeName"`
 	RmqExchangeKind       string    `json:"RmqExchangeKind"`
 	RateLimit             RateLimit `json:"RateLimit"`
+	SessionTTLDays        int       `json:"SessionTTLDays"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -12,6 +12,75 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
+type loginRequest struct {
+	Login    string `json:"login"`
+	Password string `json:"password"`
+}
+
+// Login handles POST /auth/login
+func Login(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req loginRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		// Determine client IP
+		ip := c.GetHeader("X-Real-IP")
+		if ip == "" {
+			ip = c.Request.RemoteAddr
+		}
+
+		result, err := service.Login(c.Request.Context(), pool, cfg, req.Login, req.Password, ip)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrValidation):
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			case errors.Is(err, service.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+			case errors.Is(err, service.ErrForbidden):
+				msg := strings.TrimPrefix(err.Error(), "forbidden: ")
+				c.JSON(http.StatusForbidden, gin.H{"error": msg})
+			case errors.Is(err, service.ErrUnauthorized):
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"token":       result.Token,
+			"expire_date": result.ExpireDate,
+		})
+	}
+}
+
+// Logout handles POST /auth/logout
+func Logout(pool *pgxpool.Pool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization token required"})
+			return
+		}
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+		token = strings.TrimSpace(token)
+		if token == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization token required"})
+			return
+		}
+
+		if err := service.Logout(c.Request.Context(), pool, token); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "Logged out successfully"})
+	}
+}
+
 type registerRequest struct {
 	Login    string `json:"login"`
 	Password string `json:"password"`

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -2,10 +2,13 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/darkrain/auth-service/internal/config"
@@ -19,6 +22,114 @@ var ErrValidation = errors.New("validation error")
 
 // ErrAlreadyExists is returned when email/phone is already taken.
 var ErrAlreadyExists = errors.New("already exists")
+
+// ErrNotFound is returned when the user is not found.
+var ErrNotFound = errors.New("not found")
+
+// ErrUnauthorized is returned when credentials are invalid.
+var ErrUnauthorized = errors.New("unauthorized")
+
+// ErrForbidden is returned when access is denied due to account status.
+var ErrForbidden = errors.New("forbidden")
+
+// LoginResult holds the result of a successful login.
+type LoginResult struct {
+	Token      string
+	ExpireDate time.Time
+}
+
+// Login validates credentials, creates a session, and returns a token.
+func Login(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, login, password, ip string) (*LoginResult, error) {
+	login = strings.TrimSpace(login)
+	password = strings.TrimSpace(password)
+
+	if login == "" {
+		return nil, fmt.Errorf("%w: login is required", ErrValidation)
+	}
+	if password == "" {
+		return nil, fmt.Errorf("%w: password is required", ErrValidation)
+	}
+
+	isEmail := strings.Contains(login, "@")
+
+	var userID int64
+	var storedHash string
+	var verifyStatus string
+
+	if pool != nil {
+		var query string
+		if isEmail {
+			query = `SELECT id, password, verify_status FROM users WHERE email = $1 LIMIT 1`
+		} else {
+			query = `SELECT id, password, verify_status FROM users WHERE phone = $1 LIMIT 1`
+		}
+		err := pool.QueryRow(ctx, query, login).Scan(&userID, &storedHash, &verifyStatus)
+		if err != nil {
+			return nil, fmt.Errorf("%w: user not found", ErrNotFound)
+		}
+	}
+
+	// Check verify_status
+	switch verifyStatus {
+	case "verified":
+		// OK
+	case "registered":
+		return nil, fmt.Errorf("%w: Account not verified. Please verify your email or phone.", ErrForbidden)
+	case "banned":
+		return nil, fmt.Errorf("%w: Account is banned.", ErrForbidden)
+	case "deleted":
+		return nil, fmt.Errorf("%w: Account not found.", ErrForbidden)
+	default:
+		return nil, fmt.Errorf("%w: Account access denied.", ErrForbidden)
+	}
+
+	// Verify password
+	if err := bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(cfg.PasswordSalt+password)); err != nil {
+		return nil, fmt.Errorf("%w: invalid credentials", ErrUnauthorized)
+	}
+
+	// Generate token
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, fmt.Errorf("token generation: %w", err)
+	}
+	token := hex.EncodeToString(tokenBytes)
+
+	// Calculate expiry
+	ttlDays := cfg.SessionTTLDays
+	if ttlDays <= 0 {
+		ttlDays = 30
+	}
+	expireDate := time.Now().Add(time.Duration(ttlDays) * 24 * time.Hour)
+
+	// Insert session
+	if pool != nil {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO sessions (user_id, token, expire_date, auth_type, ip, blocked) VALUES ($1, $2, $3, $4, $5, false)`,
+			userID, token, expireDate, "password", ip,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("db: insert session: %w", err)
+		}
+	}
+
+	return &LoginResult{
+		Token:      token,
+		ExpireDate: expireDate,
+	}, nil
+}
+
+// Logout marks a session as blocked.
+func Logout(ctx context.Context, pool *pgxpool.Pool, token string) error {
+	if pool == nil {
+		return nil
+	}
+	_, err := pool.Exec(ctx, `UPDATE sessions SET blocked=true WHERE token=$1`, token)
+	if err != nil {
+		return fmt.Errorf("db: update session: %w", err)
+	}
+	return nil
+}
 
 // RegisterRequest holds the registration input.
 type RegisterRequest struct {


### PR DESCRIPTION
## Summary

Implements POST /auth/login and POST /auth/logout.

## Changes

- `internal/config/config.go` — added SessionTTLDays field
- `internal/service/auth.go` — Login() and Logout() functions
- `internal/handler/auth.go` — HTTP handlers for login/logout
- `cmd/main.go` — route registration
- `auth-service.example.json` — added SessionTTLDays

## Logic

- Login accepts email OR phone, auto-detected by @
- verify_status checked before password: registered→403, banned→403, deleted→403
- Password verified: bcrypt(salt+password)
- Each successful login creates a new sessions record
- Token: crypto/rand hex 32 bytes, TTL from config
- Logout: sets session blocked=true

## Testing

Builds successfully with go build.

Fixes darkrain/auth-service#3