### PR TITLE
feat: API keys management (create, list, revoke)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/darkrain/auth-service/internal/config"
 	"github.com/darkrain/auth-service/internal/db"
 	"github.com/darkrain/auth-service/internal/handler"
+	"github.com/darkrain/auth-service/internal/middleware"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
@@ -90,6 +91,17 @@ func main() {
 	r.POST("/auth/register", handler.Register(pgPool, rmqConn, cfg))
 	r.POST("/auth/login", handler.Login(pgPool, cfg))
 	r.POST("/auth/logout", handler.Logout(pgPool))
+
+	// Protected routes (require valid session token)
+	authRequired := r.Group("/")
+	authRequired.Use(middleware.Auth(pgPool))
+
+	// API key management (admin and system only)
+	apiKeys := authRequired.Group("/auth/api-keys")
+	apiKeys.Use(middleware.RequireRole("admin", "system"))
+	apiKeys.POST("", handler.CreateAPIKey(pgPool))
+	apiKeys.GET("", handler.ListAPIKeys(pgPool))
+	apiKeys.DELETE("/:id", handler.RevokeAPIKey(pgPool))
 
 	addr := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
 	log.Printf("starting server on %s", addr)

--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/darkrain/auth-service/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CreateAPIKey handles POST /auth/api-keys
+func CreateAPIKey(pool *pgxpool.Pool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userIDVal, exists := c.Get("user_id")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			return
+		}
+		userID, ok := userIDVal.(int)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid user id"})
+			return
+		}
+
+		key, err := service.CreateAPIKey(c.Request.Context(), pool, userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create API key"})
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{
+			"id":         key.ID,
+			"token":      key.Token,
+			"created_at": key.CreatedAt,
+		})
+	}
+}
+
+// ListAPIKeys handles GET /auth/api-keys
+func ListAPIKeys(pool *pgxpool.Pool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userIDVal, exists := c.Get("user_id")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			return
+		}
+		userID, ok := userIDVal.(int)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid user id"})
+			return
+		}
+
+		keys, err := service.ListAPIKeys(c.Request.Context(), pool, userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list API keys"})
+			return
+		}
+
+		c.JSON(http.StatusOK, keys)
+	}
+}
+
+// RevokeAPIKey handles DELETE /auth/api-keys/:id
+func RevokeAPIKey(pool *pgxpool.Pool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userIDVal, exists := c.Get("user_id")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			return
+		}
+		userID, ok := userIDVal.(int)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid user id"})
+			return
+		}
+
+		keyIDStr := c.Param("id")
+		keyID, err := strconv.Atoi(keyIDStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid key id"})
+			return
+		}
+
+		if err := service.RevokeAPIKey(c.Request.Context(), pool, keyID, userID); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to revoke API key"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "API key revoked"})
+	}
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Auth middleware validates Bearer token or X-API-Key header.
+// It checks the sessions table and loads user info into gin context.
+func Auth(pool *pgxpool.Pool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var token string
+
+		// Try Authorization: Bearer <token>
+		authHeader := c.GetHeader("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			token = strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+		}
+
+		// Fallback to X-API-Key header
+		if token == "" {
+			token = strings.TrimSpace(c.GetHeader("X-API-Key"))
+		}
+
+		if token == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authorization token required"})
+			return
+		}
+
+		if pool == nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "database unavailable"})
+			return
+		}
+
+		var userID int
+		var role string
+		var verifyStatus string
+		var blocked bool
+		var expireDate *time.Time
+
+		err := pool.QueryRow(c.Request.Context(), `
+			SELECT s.user_id, u.role, u.verify_status, s.blocked, s.expire_date
+			FROM sessions s
+			JOIN users u ON u.id = s.user_id
+			WHERE s.token = $1
+		`, token).Scan(&userID, &role, &verifyStatus, &blocked, &expireDate)
+
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
+			return
+		}
+
+		if blocked {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has been revoked"})
+			return
+		}
+
+		if expireDate != nil && time.Now().After(*expireDate) {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has expired"})
+			return
+		}
+
+		c.Set("user_id", userID)
+		c.Set("role", role)
+		c.Set("verify_status", verifyStatus)
+		c.Set("token", token)
+
+		c.Next()
+	}
+}
+
+// RequireRole middleware checks that the authenticated user has one of the allowed roles.
+func RequireRole(roles ...string) gin.HandlerFunc {
+	allowed := make(map[string]struct{}, len(roles))
+	for _, r := range roles {
+		allowed[r] = struct{}{}
+	}
+
+	return func(c *gin.Context) {
+		role, exists := c.Get("role")
+		if !exists {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			return
+		}
+
+		roleStr, ok := role.(string)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid role"})
+			return
+		}
+
+		if _, ok := allowed[roleStr]; !ok {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "access denied: insufficient role"})
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/service/apikey.go
+++ b/internal/service/apikey.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// APIKey is returned when a new API key is created.
+type APIKey struct {
+	ID        int       `json:"id"`
+	Token     string    `json:"token"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// APIKeyInfo is returned in list (no token field).
+type APIKeyInfo struct {
+	ID        int       `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// CreateAPIKey generates a new API key and stores it in sessions.
+func CreateAPIKey(ctx context.Context, pool *pgxpool.Pool, userID int) (*APIKey, error) {
+	// Generate 32 random bytes → hex string (64 chars)
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return nil, fmt.Errorf("generate api key: %w", err)
+	}
+	token := hex.EncodeToString(raw)
+
+	if pool == nil {
+		return nil, fmt.Errorf("database unavailable")
+	}
+
+	var id int
+	var createdAt time.Time
+
+	err := pool.QueryRow(ctx, `
+		INSERT INTO sessions (user_id, token, auth_type, blocked)
+		VALUES ($1, $2, 'api', false)
+		RETURNING id, creation_date
+	`, userID, token).Scan(&id, &createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("db: insert api key: %w", err)
+	}
+
+	return &APIKey{
+		ID:        id,
+		Token:     token,
+		CreatedAt: createdAt,
+	}, nil
+}
+
+// ListAPIKeys returns all active API keys for a user (without the token value).
+func ListAPIKeys(ctx context.Context, pool *pgxpool.Pool, userID int) ([]APIKeyInfo, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("database unavailable")
+	}
+
+	rows, err := pool.Query(ctx, `
+		SELECT id, creation_date
+		FROM sessions
+		WHERE user_id = $1 AND auth_type = 'api' AND blocked = false
+		ORDER BY creation_date DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("db: list api keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []APIKeyInfo
+	for rows.Next() {
+		var k APIKeyInfo
+		if err := rows.Scan(&k.ID, &k.CreatedAt); err != nil {
+			return nil, fmt.Errorf("db: scan api key: %w", err)
+		}
+		keys = append(keys, k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: rows error: %w", err)
+	}
+
+	if keys == nil {
+		keys = []APIKeyInfo{}
+	}
+
+	return keys, nil
+}
+
+// RevokeAPIKey sets blocked=true for the given API key owned by userID.
+func RevokeAPIKey(ctx context.Context, pool *pgxpool.Pool, keyID, userID int) error {
+	if pool == nil {
+		return fmt.Errorf("database unavailable")
+	}
+
+	tag, err := pool.Exec(ctx, `
+		UPDATE sessions SET blocked = true
+		WHERE id = $1 AND user_id = $2 AND auth_type = 'api'
+	`, keyID, userID)
+	if err != nil {
+		return fmt.Errorf("db: revoke api key: %w", err)
+	}
+
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: api key not found", ErrNotFound)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements API key management endpoints with role-based access control.

## Changes

- `internal/middleware/auth.go` — Auth middleware (Bearer + X-API-Key) and RequireRole middleware
- `internal/service/apikey.go` — CreateAPIKey, ListAPIKeys, RevokeAPIKey
- `internal/handler/apikey.go` — HTTP handlers
- `cmd/main.go` — routes with middleware groups

## Logic

- Only admin/system roles can create/manage API keys
- API key stored in sessions with auth_type=api
- Token returned only at creation, not in list
- Revoke sets blocked=true
- Auth middleware validates both Bearer token and X-API-Key header

## Testing

Builds successfully with go build.

Fixes darkrain/auth-service#4