### PR TITLE
feat: email/phone verification and 2FA

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -22,6 +22,7 @@
   "RmqExchangeName": "mail",
   "RmqExchangeKind": "direct",
   "SessionTTLDays": 30,
+  "TwoFactorEnabled": false,
   "RateLimit": {
     "IP": {
       "LoginMaxAttempts": 5,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,8 +89,12 @@ func main() {
 	})
 
 	r.POST("/auth/register", handler.Register(pgPool, rmqConn, cfg))
-	r.POST("/auth/login", handler.Login(pgPool, cfg))
+	r.POST("/auth/login", handler.Login(pgPool, rmqConn, cfg))
 	r.POST("/auth/logout", handler.Logout(pgPool))
+	r.POST("/auth/send-code", handler.SendCode(pgPool, rmqConn, cfg))
+	r.POST("/auth/verify/email", handler.VerifyEmail(pgPool, cfg))
+	r.POST("/auth/verify/phone", handler.VerifyPhone(pgPool, cfg))
+	r.POST("/auth/login/verify-2fa", handler.VerifyLogin2FA(pgPool, cfg))
 
 	// Protected routes (require valid session token)
 	authRequired := r.Group("/")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	RmqExchangeKind       string    `json:"RmqExchangeKind"`
 	RateLimit             RateLimit `json:"RateLimit"`
 	SessionTTLDays        int       `json:"SessionTTLDays"`
+	TwoFactorEnabled      bool      `json:"TwoFactorEnabled"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -13,12 +13,13 @@ import (
 )
 
 type loginRequest struct {
-	Login    string `json:"login"`
-	Password string `json:"password"`
+	Login     string `json:"login"`
+	Password  string `json:"password"`
+	DeviceUID string `json:"device_uid"`
 }
 
 // Login handles POST /auth/login
-func Login(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
+func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req loginRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -35,6 +36,13 @@ func Login(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 		result, err := service.Login(c.Request.Context(), pool, cfg, req.Login, req.Password, ip)
 		if err != nil {
 			switch {
+			case errors.Is(err, service.Err2FA):
+				// Send code and return 202
+				_ = service.SendCode(c.Request.Context(), pool, conn, cfg, req.Login, req.DeviceUID)
+				c.JSON(http.StatusAccepted, gin.H{
+					"message":      "Code sent to your email/phone. Please verify.",
+					"requires_2fa": true,
+				})
 			case errors.Is(err, service.ErrValidation):
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			case errors.Is(err, service.ErrNotFound):

--- a/internal/handler/verification.go
+++ b/internal/handler/verification.go
@@ -1,0 +1,150 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/darkrain/auth-service/internal/config"
+	"github.com/darkrain/auth-service/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type sendCodeRequest struct {
+	Recipient string `json:"recipient"`
+	DeviceUID string `json:"device_uid"`
+}
+
+// SendCode handles POST /auth/send-code
+func SendCode(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req sendCodeRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		req.Recipient = strings.TrimSpace(req.Recipient)
+		req.DeviceUID = strings.TrimSpace(req.DeviceUID)
+
+		if req.Recipient == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "recipient is required"})
+			return
+		}
+
+		err := service.SendCode(c.Request.Context(), pool, conn, cfg, req.Recipient, req.DeviceUID)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrTooManyRequests):
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+			case errors.Is(err, service.ErrValidation):
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "Code sent"})
+	}
+}
+
+type verifyCodeRequest struct {
+	Recipient string `json:"recipient"`
+	Code      string `json:"code"`
+	DeviceUID string `json:"device_uid"`
+}
+
+// VerifyEmail handles POST /auth/verify/email
+func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req verifyCodeRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "email")
+		if err != nil {
+			handleVerifyError(c, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "Verified successfully"})
+	}
+}
+
+// VerifyPhone handles POST /auth/verify/phone
+func VerifyPhone(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req verifyCodeRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "phone")
+		if err != nil {
+			handleVerifyError(c, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "Verified successfully"})
+	}
+}
+
+type verifyLogin2FARequest struct {
+	Login     string `json:"login"`
+	Code      string `json:"code"`
+	DeviceUID string `json:"device_uid"`
+}
+
+// VerifyLogin2FA handles POST /auth/login/verify-2fa
+func VerifyLogin2FA(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req verifyLogin2FARequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		ip := c.GetHeader("X-Real-IP")
+		if ip == "" {
+			ip = c.Request.RemoteAddr
+		}
+
+		result, err := service.LoginVerify2FA(c.Request.Context(), pool, cfg, service.Login2FARequest{
+			Login:     req.Login,
+			Code:      req.Code,
+			DeviceUID: req.DeviceUID,
+			IP:        ip,
+		})
+		if err != nil {
+			handleVerifyError(c, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"token":       result.Token,
+			"expire_date": result.ExpireDate,
+		})
+	}
+}
+
+// handleVerifyError maps service errors to HTTP responses.
+func handleVerifyError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrTooManyRequests):
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrValidation):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrUnauthorized):
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid verification code"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+	}
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -38,7 +38,16 @@ type LoginResult struct {
 	ExpireDate time.Time
 }
 
+// Login2FARequest holds the request for 2FA login verification.
+type Login2FARequest struct {
+	Login     string
+	Code      string
+	DeviceUID string
+	IP        string
+}
+
 // Login validates credentials, creates a session, and returns a token.
+// If cfg.TwoFactorEnabled is true and password is valid, returns Err2FA without creating session.
 func Login(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, login, password, ip string) (*LoginResult, error) {
 	login = strings.TrimSpace(login)
 	password = strings.TrimSpace(password)
@@ -88,6 +97,13 @@ func Login(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, login, p
 		return nil, fmt.Errorf("%w: invalid credentials", ErrUnauthorized)
 	}
 
+	// 2FA: if enabled, send code and return Err2FA instead of creating session
+	if cfg.TwoFactorEnabled {
+		// deviceUID not available here — caller must handle via /auth/login/verify-2fa
+		// We just signal that 2FA is required; SendCode is called from the handler
+		return nil, fmt.Errorf("%w: 2fa required", Err2FA)
+	}
+
 	// Generate token
 	tokenBytes := make([]byte, 32)
 	if _, err := rand.Read(tokenBytes); err != nil {
@@ -117,6 +133,108 @@ func Login(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, login, p
 		Token:      token,
 		ExpireDate: expireDate,
 	}, nil
+}
+
+// createSession generates a token, inserts a session, and returns LoginResult.
+func createSession(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, userID int64, ip string) (*LoginResult, error) {
+	// Generate token
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, fmt.Errorf("token generation: %w", err)
+	}
+	token := hex.EncodeToString(tokenBytes)
+
+	// Calculate expiry
+	ttlDays := cfg.SessionTTLDays
+	if ttlDays <= 0 {
+		ttlDays = 30
+	}
+	expireDate := time.Now().Add(time.Duration(ttlDays) * 24 * time.Hour)
+
+	if pool != nil {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO sessions (user_id, token, expire_date, auth_type, ip, blocked) VALUES ($1, $2, $3, $4, $5, false)`,
+			userID, token, expireDate, "password", ip,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("db: insert session: %w", err)
+		}
+	}
+
+	return &LoginResult{
+		Token:      token,
+		ExpireDate: expireDate,
+	}, nil
+}
+
+// LoginVerify2FA verifies the 2FA code for a given login and creates a session if valid.
+func LoginVerify2FA(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, req Login2FARequest) (*LoginResult, error) {
+	req.Login = strings.TrimSpace(req.Login)
+	if req.Login == "" {
+		return nil, fmt.Errorf("%w: login is required", ErrValidation)
+	}
+
+	// Determine field type and find user
+	isEmail := strings.Contains(req.Login, "@")
+
+	var userID int64
+	if pool != nil {
+		var query string
+		if isEmail {
+			query = `SELECT id FROM users WHERE email = $1 LIMIT 1`
+		} else {
+			query = `SELECT id FROM users WHERE phone = $1 LIMIT 1`
+		}
+		if err := pool.QueryRow(ctx, query, req.Login).Scan(&userID); err != nil {
+			return nil, fmt.Errorf("%w: user not found", ErrNotFound)
+		}
+	}
+
+	// Verify the code (uses email/phone type for user update)
+	verifyType := "phone"
+	if isEmail {
+		verifyType = "email"
+	}
+
+	// For 2FA verify, we just check and delete the code but don't set email_verified/phone_verified here
+	// We do a direct code check without updating user's verified status
+	if pool != nil {
+		var storedCode string
+		var counter int64
+		var sentTS int64
+
+		err := pool.QueryRow(ctx,
+			`SELECT code, counter, sent_ts FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 LIMIT 1`,
+			req.DeviceUID, req.Login,
+		).Scan(&storedCode, &counter, &sentTS)
+		if err != nil {
+			return nil, fmt.Errorf("%w: verification code not found", ErrNotFound)
+		}
+
+		now := time.Now().Unix()
+		if cfg.RateLimit.Code.TTLSec > 0 && sentTS+int64(cfg.RateLimit.Code.TTLSec) <= now {
+			return nil, fmt.Errorf("%w: verification code has expired", ErrValidation)
+		}
+		if cfg.RateLimit.Code.MaxAttempts > 0 && counter >= int64(cfg.RateLimit.Code.MaxAttempts) {
+			return nil, fmt.Errorf("%w: Too many attempts. Request a new code.", ErrTooManyRequests)
+		}
+		if req.Code != storedCode {
+			_, _ = pool.Exec(ctx,
+				`UPDATE confirm_codes SET counter=counter+1 WHERE device_uid=$1 AND recipient=$2`,
+				req.DeviceUID, req.Login,
+			)
+			return nil, fmt.Errorf("%w: invalid verification code", ErrUnauthorized)
+		}
+
+		// Delete the used code
+		_, _ = pool.Exec(ctx,
+			`DELETE FROM confirm_codes WHERE device_uid=$1 AND recipient=$2`,
+			req.DeviceUID, req.Login,
+		)
+		_ = verifyType // used for VerifyCode path, not needed here
+	}
+
+	return createSession(ctx, pool, cfg, userID, req.IP)
 }
 
 // Logout marks a session as blocked.

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -1,0 +1,217 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/darkrain/auth-service/internal/config"
+	"github.com/jackc/pgx/v5/pgxpool"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// ErrTooManyRequests is returned when the rate limit is exceeded.
+var ErrTooManyRequests = errors.New("too many requests")
+
+// Err2FA is returned when 2FA is required after successful password check.
+var Err2FA = errors.New("2fa required")
+
+// SendCode generates a 6-digit verification code and publishes it to RabbitMQ.
+// Rate-limited: if an existing code's TTL hasn't expired, returns ErrTooManyRequests.
+func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config, recipient, deviceUID string) error {
+	recipient = strings.TrimSpace(recipient)
+	if recipient == "" {
+		return fmt.Errorf("%w: recipient is required", ErrValidation)
+	}
+
+	isEmail := strings.Contains(recipient, "@")
+
+	// Find user_id by recipient
+	var userID int64
+	if pool != nil {
+		var query string
+		if isEmail {
+			query = `SELECT id FROM users WHERE email = $1 LIMIT 1`
+		} else {
+			query = `SELECT id FROM users WHERE phone = $1 LIMIT 1`
+		}
+		if err := pool.QueryRow(ctx, query, recipient).Scan(&userID); err != nil {
+			// user not found — still proceed (don't leak existence)
+			userID = 0
+		}
+	}
+
+	// Check rate limit: if existing record has unexpired TTL, reject
+	if pool != nil && cfg.RateLimit.Code.TTLSec > 0 {
+		var oldSentTS int64
+		err := pool.QueryRow(ctx,
+			`SELECT sent_ts FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 LIMIT 1`,
+			deviceUID, recipient,
+		).Scan(&oldSentTS)
+		if err == nil {
+			// Record exists — check TTL
+			now := time.Now().Unix()
+			if oldSentTS+int64(cfg.RateLimit.Code.TTLSec) > now {
+				return fmt.Errorf("%w: code already sent, please wait before requesting a new one", ErrTooManyRequests)
+			}
+		}
+		// err != nil means no row → first time, fine
+	}
+
+	// Generate 6-digit code
+	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return fmt.Errorf("crypto/rand: %w", err)
+	}
+	code := fmt.Sprintf("%06d", n.Int64())
+
+	now := time.Now().Unix()
+
+	// UPSERT into confirm_codes
+	if pool != nil {
+		_, err = pool.Exec(ctx,
+			`INSERT INTO confirm_codes (device_uid, recipient, code, counter, sent_ts)
+			 VALUES ($1, $2, $3, 0, $4)
+			 ON CONFLICT (device_uid, recipient) DO UPDATE
+			 SET code = EXCLUDED.code, counter = 0, sent_ts = EXCLUDED.sent_ts`,
+			deviceUID, recipient, code, now,
+		)
+		if err != nil {
+			return fmt.Errorf("db: upsert confirm_codes: %w", err)
+		}
+	}
+
+	// Publish event to RabbitMQ
+	if conn != nil {
+		eventType := "phone_verification"
+		if isEmail {
+			eventType = "email_verification"
+		}
+
+		type verificationEvent struct {
+			Type      string `json:"type"`
+			Recipient string `json:"recipient"`
+			Code      string `json:"code"`
+			UserID    int64  `json:"user_id"`
+		}
+
+		payload, err := json.Marshal(verificationEvent{
+			Type:      eventType,
+			Recipient: recipient,
+			Code:      code,
+			UserID:    userID,
+		})
+		if err != nil {
+			return fmt.Errorf("json: marshal event: %w", err)
+		}
+
+		ch, err := conn.Channel()
+		if err != nil {
+			return fmt.Errorf("broker: open channel: %w", err)
+		}
+		defer ch.Close()
+
+		if err := ch.ExchangeDeclare(
+			cfg.RmqExchangeName,
+			cfg.RmqExchangeKind,
+			true,
+			false,
+			false,
+			false,
+			nil,
+		); err != nil {
+			return fmt.Errorf("broker: declare exchange: %w", err)
+		}
+
+		if err := ch.PublishWithContext(ctx,
+			cfg.RmqExchangeName,
+			cfg.RmqQueueMailName,
+			false,
+			false,
+			amqp.Publishing{
+				ContentType: "application/json",
+				Body:        payload,
+			},
+		); err != nil {
+			return fmt.Errorf("broker: publish: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// VerifyCode checks a verification code for the given recipient+deviceUID.
+// verifyType must be "email" or "phone".
+func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, recipient, code, deviceUID, verifyType string) error {
+	recipient = strings.TrimSpace(recipient)
+	code = strings.TrimSpace(code)
+
+	if pool == nil {
+		return nil
+	}
+
+	var storedCode string
+	var counter int64
+	var sentTS int64
+
+	err := pool.QueryRow(ctx,
+		`SELECT code, counter, sent_ts FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 LIMIT 1`,
+		deviceUID, recipient,
+	).Scan(&storedCode, &counter, &sentTS)
+	if err != nil {
+		return fmt.Errorf("%w: verification code not found", ErrNotFound)
+	}
+
+	now := time.Now().Unix()
+
+	// Check TTL
+	if cfg.RateLimit.Code.TTLSec > 0 && sentTS+int64(cfg.RateLimit.Code.TTLSec) <= now {
+		return fmt.Errorf("%w: verification code has expired", ErrValidation)
+	}
+
+	// Check attempt counter
+	if cfg.RateLimit.Code.MaxAttempts > 0 && counter >= int64(cfg.RateLimit.Code.MaxAttempts) {
+		return fmt.Errorf("%w: Too many attempts. Request a new code.", ErrTooManyRequests)
+	}
+
+	// Compare code
+	if code != storedCode {
+		// Increment counter
+		_, _ = pool.Exec(ctx,
+			`UPDATE confirm_codes SET counter=counter+1 WHERE device_uid=$1 AND recipient=$2`,
+			deviceUID, recipient,
+		)
+		return fmt.Errorf("%w: invalid verification code", ErrUnauthorized)
+	}
+
+	// Code is correct — update user and delete confirm record
+	if verifyType == "email" {
+		_, err = pool.Exec(ctx,
+			`UPDATE users SET email_verified=true, verify_status='verified' WHERE email=$1`,
+			recipient,
+		)
+	} else {
+		_, err = pool.Exec(ctx,
+			`UPDATE users SET phone_verified=true, verify_status='verified' WHERE phone=$1`,
+			recipient,
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("db: update user verified: %w", err)
+	}
+
+	_, err = pool.Exec(ctx,
+		`DELETE FROM confirm_codes WHERE device_uid=$1 AND recipient=$2`,
+		deviceUID, recipient,
+	)
+	if err != nil {
+		return fmt.Errorf("db: delete confirm_codes: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements email/phone verification flow and optional 2FA.

## Changes

- `internal/config/config.go` — TwoFactorEnabled field
- `auth-service.example.json` — TwoFactorEnabled: false
- `internal/service/verification.go` — SendCode, VerifyCode (new file)
- `internal/handler/verification.go` — HTTP handlers (new file)
- `internal/service/auth.go` — 2FA support in Login, createSession helper, LoginVerify2FA
- `internal/handler/auth.go` — 2FA response + verify-2fa endpoint, Login now takes conn
- `cmd/main.go` — routes

## Logic

- 6-digit code via crypto/rand, UPSERT in confirm_codes, published to RabbitMQ
- Rate limited by TTL (sent_ts + TTLSec) and attempt counter (< MaxAttempts)
- On verify: sets verified=true, verify_status=verified, deletes confirm_code entry
- 2FA: if TwoFactorEnabled, Login returns Err2FA, handler calls SendCode and returns 202
- POST /auth/login/verify-2fa: checks code, creates session, returns token

## Testing

Builds successfully with `CGO_ENABLED=0 go build ./cmd/main.go`.

Fixes darkrain/auth-service#5