### PR TITLE
feat: GET /auth/me with Redis session cache

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/darkrain/auth-service/internal/broker"
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/darkrain/auth-service/internal/config"
 	"github.com/darkrain/auth-service/internal/db"
 	"github.com/darkrain/auth-service/internal/handler"
@@ -72,6 +73,8 @@ func main() {
 		}
 	}()
 
+	cacheClient := cache.NewClient(cfg)
+
 	// RabbitMQ
 	rmqConn, err := broker.Connect(cfg)
 	if err != nil {
@@ -90,7 +93,7 @@ func main() {
 
 	r.POST("/auth/register", handler.Register(pgPool, rmqConn, cfg))
 	r.POST("/auth/login", handler.Login(pgPool, rmqConn, cfg))
-	r.POST("/auth/logout", handler.Logout(pgPool))
+	r.POST("/auth/logout", handler.Logout(pgPool, cacheClient))
 	r.POST("/auth/send-code", handler.SendCode(pgPool, rmqConn, cfg))
 	r.POST("/auth/verify/email", handler.VerifyEmail(pgPool, cfg))
 	r.POST("/auth/verify/phone", handler.VerifyPhone(pgPool, cfg))
@@ -98,14 +101,17 @@ func main() {
 
 	// Protected routes (require valid session token)
 	authRequired := r.Group("/")
-	authRequired.Use(middleware.Auth(pgPool))
+	authRequired.Use(middleware.Auth(pgPool, cacheClient))
 
 	// API key management (admin and system only)
 	apiKeys := authRequired.Group("/auth/api-keys")
 	apiKeys.Use(middleware.RequireRole("admin", "system"))
 	apiKeys.POST("", handler.CreateAPIKey(pgPool))
 	apiKeys.GET("", handler.ListAPIKeys(pgPool))
-	apiKeys.DELETE("/:id", handler.RevokeAPIKey(pgPool))
+	apiKeys.DELETE("/:id", handler.RevokeAPIKey(pgPool, cacheClient))
+
+	// Authenticated user info
+	authRequired.GET("/auth/me", handler.Me())
 
 	addr := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
 	log.Printf("starting server on %s", addr)

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/darkrain/auth-service/internal/config"
+	"github.com/redis/go-redis/v9"
+)
+
+// SessionData holds the cached user session info.
+type SessionData struct {
+	UserID       int    `json:"user_id"`
+	Email        string `json:"email"`
+	Phone        string `json:"phone"`
+	Role         string `json:"role"`
+	VerifyStatus string `json:"verify_status"`
+}
+
+// Client wraps a redis.Client with session-specific helpers.
+type Client struct {
+	rdb *redis.Client
+}
+
+// NewClient creates a Redis client from config.
+func NewClient(cfg *config.Config) *Client {
+	rdb := redis.NewClient(&redis.Options{
+		Network: cfg.RedisDatabaseNetwork,
+		Addr:    cfg.RedisDatabaseHost + ":" + cfg.RedisDatabasePort,
+	})
+	return &Client{rdb: rdb}
+}
+
+func sessionKey(token string) string {
+	return "session:" + token
+}
+
+// GetSession retrieves session data from Redis cache.
+// Returns nil, nil if not found.
+func (c *Client) GetSession(ctx context.Context, token string) (*SessionData, error) {
+	val, err := c.rdb.Get(ctx, sessionKey(token)).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var data SessionData
+	if err := json.Unmarshal([]byte(val), &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+// SetSession stores session data in Redis with a TTL.
+func (c *Client) SetSession(ctx context.Context, token string, data *SessionData, ttl time.Duration) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return c.rdb.Set(ctx, sessionKey(token), b, ttl).Err()
+}
+
+// DeleteSession removes session data from Redis cache.
+func (c *Client) DeleteSession(ctx context.Context, token string) error {
+	return c.rdb.Del(ctx, sessionKey(token)).Err()
+}

--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/darkrain/auth-service/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -63,7 +64,7 @@ func ListAPIKeys(pool *pgxpool.Pool) gin.HandlerFunc {
 }
 
 // RevokeAPIKey handles DELETE /auth/api-keys/:id
-func RevokeAPIKey(pool *pgxpool.Pool) gin.HandlerFunc {
+func RevokeAPIKey(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userIDVal, exists := c.Get("user_id")
 		if !exists {
@@ -83,7 +84,7 @@ func RevokeAPIKey(pool *pgxpool.Pool) gin.HandlerFunc {
 			return
 		}
 
-		if err := service.RevokeAPIKey(c.Request.Context(), pool, keyID, userID); err != nil {
+		if err := service.RevokeAPIKey(c.Request.Context(), pool, cacheClient, keyID, userID); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})
 				return

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/darkrain/auth-service/internal/config"
 	"github.com/darkrain/auth-service/internal/service"
 	"github.com/gin-gonic/gin"
@@ -66,7 +67,7 @@ func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin.Ha
 }
 
 // Logout handles POST /auth/logout
-func Logout(pool *pgxpool.Pool) gin.HandlerFunc {
+func Logout(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 		if !strings.HasPrefix(authHeader, "Bearer ") {
@@ -80,12 +81,31 @@ func Logout(pool *pgxpool.Pool) gin.HandlerFunc {
 			return
 		}
 
-		if err := service.Logout(c.Request.Context(), pool, token); err != nil {
+		if err := service.Logout(c.Request.Context(), pool, cacheClient, token); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{"message": "Logged out successfully"})
+	}
+}
+
+// Me handles GET /auth/me — returns current user data from session context.
+func Me() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get("user_id")
+		email, _ := c.Get("email")
+		phone, _ := c.Get("phone")
+		role, _ := c.Get("role")
+		verifyStatus, _ := c.Get("verify_status")
+
+		c.JSON(http.StatusOK, gin.H{
+			"id":            userID,
+			"email":         email,
+			"phone":         phone,
+			"role":          role,
+			"verify_status": verifyStatus,
+		})
 	}
 }
 

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -5,13 +5,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Auth middleware validates Bearer token or X-API-Key header.
-// It checks the sessions table and loads user info into gin context.
-func Auth(pool *pgxpool.Pool) gin.HandlerFunc {
+// It checks the Redis cache first; on cache miss it queries the sessions table,
+// then caches the result with TTL = expire_date - now.
+func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var token string
 
@@ -31,23 +33,37 @@ func Auth(pool *pgxpool.Pool) gin.HandlerFunc {
 			return
 		}
 
+		// 1. Check Redis cache
+		if cacheClient != nil {
+			if sd, err := cacheClient.GetSession(c.Request.Context(), token); err == nil && sd != nil {
+				c.Set("user_id", sd.UserID)
+				c.Set("email", sd.Email)
+				c.Set("phone", sd.Phone)
+				c.Set("role", sd.Role)
+				c.Set("verify_status", sd.VerifyStatus)
+				c.Set("token", token)
+				c.Next()
+				return
+			}
+		}
+
+		// 2. Cache miss — query DB
 		if pool == nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "database unavailable"})
 			return
 		}
 
 		var userID int
-		var role string
-		var verifyStatus string
+		var email, phone, role, verifyStatus string
 		var blocked bool
 		var expireDate *time.Time
 
 		err := pool.QueryRow(c.Request.Context(), `
-			SELECT s.user_id, u.role, u.verify_status, s.blocked, s.expire_date
+			SELECT s.user_id, COALESCE(u.email,''), COALESCE(u.phone,''), u.role, u.verify_status, s.blocked, s.expire_date
 			FROM sessions s
 			JOIN users u ON u.id = s.user_id
 			WHERE s.token = $1
-		`, token).Scan(&userID, &role, &verifyStatus, &blocked, &expireDate)
+		`, token).Scan(&userID, &email, &phone, &role, &verifyStatus, &blocked, &expireDate)
 
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
@@ -64,7 +80,29 @@ func Auth(pool *pgxpool.Pool) gin.HandlerFunc {
 			return
 		}
 
+		// 3. Store in Redis cache with TTL = expire_date - now
+		if cacheClient != nil {
+			sd := &cache.SessionData{
+				UserID:       userID,
+				Email:        email,
+				Phone:        phone,
+				Role:         role,
+				VerifyStatus: verifyStatus,
+			}
+			var ttl time.Duration
+			if expireDate != nil {
+				ttl = time.Until(*expireDate)
+			} else {
+				ttl = 24 * time.Hour // default TTL for API keys without expiry
+			}
+			if ttl > 0 {
+				_ = cacheClient.SetSession(c.Request.Context(), token, sd, ttl)
+			}
+		}
+
 		c.Set("user_id", userID)
+		c.Set("email", email)
+		c.Set("phone", phone)
 		c.Set("role", role)
 		c.Set("verify_status", verifyStatus)
 		c.Set("token", token)

--- a/internal/service/apikey.go
+++ b/internal/service/apikey.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -91,11 +92,15 @@ func ListAPIKeys(ctx context.Context, pool *pgxpool.Pool, userID int) ([]APIKeyI
 	return keys, nil
 }
 
-// RevokeAPIKey sets blocked=true for the given API key owned by userID.
-func RevokeAPIKey(ctx context.Context, pool *pgxpool.Pool, keyID, userID int) error {
+// RevokeAPIKey sets blocked=true for the given API key owned by userID and invalidates Redis cache.
+func RevokeAPIKey(ctx context.Context, pool *pgxpool.Pool, cacheClient *cache.Client, keyID, userID int) error {
 	if pool == nil {
 		return fmt.Errorf("database unavailable")
 	}
+
+	// Fetch token before blocking so we can invalidate cache
+	var token string
+	_ = pool.QueryRow(ctx, `SELECT token FROM sessions WHERE id=$1 AND user_id=$2`, keyID, userID).Scan(&token)
 
 	tag, err := pool.Exec(ctx, `
 		UPDATE sessions SET blocked = true
@@ -107,6 +112,10 @@ func RevokeAPIKey(ctx context.Context, pool *pgxpool.Pool, keyID, userID int) er
 
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("%w: api key not found", ErrNotFound)
+	}
+
+	if cacheClient != nil && token != "" {
+		_ = cacheClient.DeleteSession(ctx, token)
 	}
 
 	return nil

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/darkrain/auth-service/internal/config"
 	"github.com/jackc/pgx/v5/pgxpool"
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -237,14 +238,17 @@ func LoginVerify2FA(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config,
 	return createSession(ctx, pool, cfg, userID, req.IP)
 }
 
-// Logout marks a session as blocked.
-func Logout(ctx context.Context, pool *pgxpool.Pool, token string) error {
+// Logout marks a session as blocked and invalidates the Redis cache.
+func Logout(ctx context.Context, pool *pgxpool.Pool, cacheClient *cache.Client, token string) error {
 	if pool == nil {
 		return nil
 	}
 	_, err := pool.Exec(ctx, `UPDATE sessions SET blocked=true WHERE token=$1`, token)
 	if err != nil {
 		return fmt.Errorf("db: update session: %w", err)
+	}
+	if cacheClient != nil {
+		_ = cacheClient.DeleteSession(ctx, token)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Implements GET /auth/me and adds Redis caching to session validation.

## Changes

- `internal/cache/redis.go` — Redis client, SessionData, GetSession/SetSession/DeleteSession
- `internal/middleware/auth.go` — Redis-first session lookup, fallback to DB
- `internal/service/auth.go` — Logout invalidates Redis cache
- `internal/service/apikey.go` — RevokeAPIKey invalidates Redis cache
- `internal/handler/auth.go` — GET /auth/me handler
- `internal/handler/apikey.go` — RevokeAPIKey accepts cache client
- `cmd/main.go` — cache init, updated calls

## Logic

- Auth middleware: Redis cache → DB → cache (TTL = expire_date - now)
- GET /auth/me returns id, email, phone, role, verify_status from context
- Cache invalidated on logout and API key revoke

## Testing

Builds successfully with go build.

Fixes darkrain/auth-service#6