### PR TITLE
feat: rate limiting and account protection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,10 +91,22 @@ func main() {
 		c.JSON(http.StatusOK, gin.H{"status": "ok", "version": Version})
 	})
 
-	r.POST("/auth/register", handler.Register(pgPool, rmqConn, cfg))
-	r.POST("/auth/login", handler.Login(pgPool, rmqConn, cfg))
+	r.POST("/auth/register",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/register",
+			cfg.RateLimit.IP.RegisterMaxAttempts, cfg.RateLimit.IP.RegisterWindowSec,
+			cfg.RateLimit.Device.RegisterMaxAttempts, cfg.RateLimit.Device.RegisterWindowSec),
+		handler.Register(pgPool, rmqConn, cfg))
+	r.POST("/auth/login",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/login",
+			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
+			cfg.RateLimit.Device.LoginMaxAttempts, cfg.RateLimit.Device.LoginWindowSec),
+		handler.Login(pgPool, rmqConn, cfg, cacheClient))
 	r.POST("/auth/logout", handler.Logout(pgPool, cacheClient))
-	r.POST("/auth/send-code", handler.SendCode(pgPool, rmqConn, cfg))
+	r.POST("/auth/send-code",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/send-code",
+			0, 0,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.SendCode(pgPool, rmqConn, cfg))
 	r.POST("/auth/verify/email", handler.VerifyEmail(pgPool, cfg))
 	r.POST("/auth/verify/phone", handler.VerifyPhone(pgPool, cfg))
 	r.POST("/auth/login/verify-2fa", handler.VerifyLogin2FA(pgPool, cfg))

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/darkrain/auth-service/internal/config"
@@ -67,4 +68,65 @@ func (c *Client) SetSession(ctx context.Context, token string, data *SessionData
 // DeleteSession removes session data from Redis cache.
 func (c *Client) DeleteSession(ctx context.Context, token string) error {
 	return c.rdb.Del(ctx, sessionKey(token)).Err()
+}
+
+// SlidingWindowIncr increments a sliding window counter in Redis.
+// Uses INCR + EXPIRE pattern: if key is new (count==1), set TTL to windowSec.
+// Returns the current count after increment.
+func (c *Client) SlidingWindowIncr(ctx context.Context, key string, windowSec int) (int64, error) {
+	count, err := c.rdb.Incr(ctx, key).Result()
+	if err != nil {
+		return 0, err
+	}
+	if count == 1 {
+		_ = c.rdb.Expire(ctx, key, time.Duration(windowSec)*time.Second).Err()
+	}
+	return count, nil
+}
+
+// IsAccountLocked checks whether an account is temporarily locked.
+// Key: "lock:user:{userID}"
+func (c *Client) IsAccountLocked(ctx context.Context, userID int) (bool, error) {
+	key := fmt.Sprintf("lock:user:%d", userID)
+	exists, err := c.rdb.Exists(ctx, key).Result()
+	if err != nil {
+		return false, err
+	}
+	return exists > 0, nil
+}
+
+// LockAccount temporarily locks an account for durationSec seconds.
+// Key: "lock:user:{userID}"
+func (c *Client) LockAccount(ctx context.Context, userID int, durationSec int) error {
+	key := fmt.Sprintf("lock:user:%d", userID)
+	return c.rdb.Set(ctx, key, 1, time.Duration(durationSec)*time.Second).Err()
+}
+
+// IncrFailedLogin increments the failed login counter for a user.
+// If the counter reaches maxAttempts, the account is locked for lockDurationSec seconds.
+// Key: "failedlogin:{userID}"
+func (c *Client) IncrFailedLogin(ctx context.Context, userID int, maxAttempts int, lockDurationSec int) error {
+	key := fmt.Sprintf("failedlogin:%d", userID)
+	count, err := c.rdb.Incr(ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	// Set TTL on first increment to auto-expire the counter
+	if count == 1 {
+		_ = c.rdb.Expire(ctx, key, time.Duration(lockDurationSec)*time.Second).Err()
+	}
+	if maxAttempts > 0 && count >= int64(maxAttempts) {
+		if lockErr := c.LockAccount(ctx, userID, lockDurationSec); lockErr != nil {
+			return lockErr
+		}
+		_ = c.rdb.Del(ctx, key).Err()
+	}
+	return nil
+}
+
+// ResetFailedLogin resets the failed login counter on successful login.
+// Key: "failedlogin:{userID}"
+func (c *Client) ResetFailedLogin(ctx context.Context, userID int) error {
+	key := fmt.Sprintf("failedlogin:%d", userID)
+	return c.rdb.Del(ctx, key).Err()
 }

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -20,7 +20,7 @@ type loginRequest struct {
 }
 
 // Login handles POST /auth/login
-func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin.HandlerFunc {
+func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config, cacheClient *cache.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req loginRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -34,7 +34,7 @@ func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin.Ha
 			ip = c.Request.RemoteAddr
 		}
 
-		result, err := service.Login(c.Request.Context(), pool, cfg, req.Login, req.Password, ip)
+		result, err := service.Login(c.Request.Context(), pool, cfg, cacheClient, req.Login, req.Password, ip)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.Err2FA):
@@ -44,6 +44,8 @@ func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin.Ha
 					"message":      "Code sent to your email/phone. Please verify.",
 					"requires_2fa": true,
 				})
+			case errors.Is(err, service.ErrAccountLocked):
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "Account temporarily locked due to too many failed attempts"})
 			case errors.Is(err, service.ErrValidation):
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			case errors.Is(err, service.ErrNotFound):

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,0 +1,118 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/darkrain/auth-service/internal/cache"
+	"github.com/gin-gonic/gin"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// RateLimit returns a Gin middleware that applies sliding window rate limiting
+// by IP and optionally by device_uid (X-Device-ID header).
+//
+// endpoint: path string used as part of Redis key (e.g. "/auth/login")
+// ipMax, ipWindowSec: IP-based limits (0 = skip IP check)
+// deviceMax, deviceWindowSec: device-based limits (0 = skip device check)
+func RateLimit(cacheClient *cache.Client, conn *amqp.Connection, endpoint string,
+	ipMax, ipWindowSec, deviceMax, deviceWindowSec int) gin.HandlerFunc {
+
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		// 1. Get client IP (prefer X-Real-IP, strip port from RemoteAddr)
+		ip := c.GetHeader("X-Real-IP")
+		if ip == "" {
+			host, _, err := net.SplitHostPort(c.Request.RemoteAddr)
+			if err != nil {
+				ip = c.Request.RemoteAddr
+			} else {
+				ip = host
+			}
+		}
+
+		// 2. Get device_uid from X-Device-ID header
+		deviceUID := c.GetHeader("X-Device-ID")
+
+		// 3. Check IP rate limit
+		if ipMax > 0 && ipWindowSec > 0 && cacheClient != nil {
+			key := fmt.Sprintf("rl:ip:%s:%s", endpoint, ip)
+			count, err := cacheClient.SlidingWindowIncr(ctx, key, ipWindowSec)
+			if err == nil && count > int64(ipMax) {
+				publishSecurityEvent(conn, "rate_limit_exceeded", map[string]interface{}{
+					"type":     "ip",
+					"endpoint": endpoint,
+					"ip":       ip,
+					"count":    count,
+					"ts":       time.Now().Unix(),
+				})
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "Too many requests. Try again later."})
+				return
+			}
+		}
+
+		// 4. Check device rate limit (only if device_uid is provided)
+		if deviceUID != "" && deviceMax > 0 && deviceWindowSec > 0 && cacheClient != nil {
+			key := fmt.Sprintf("rl:device:%s:%s", endpoint, deviceUID)
+			count, err := cacheClient.SlidingWindowIncr(ctx, key, deviceWindowSec)
+			if err == nil && count > int64(deviceMax) {
+				publishSecurityEvent(conn, "rate_limit_exceeded", map[string]interface{}{
+					"type":      "device",
+					"endpoint":  endpoint,
+					"device_id": deviceUID,
+					"ip":        ip,
+					"count":     count,
+					"ts":        time.Now().Unix(),
+				})
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "Too many requests. Try again later."})
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+
+// publishSecurityEvent publishes a security event to RabbitMQ asynchronously.
+// Does not block the main request.
+func publishSecurityEvent(conn *amqp.Connection, eventType string, payload map[string]interface{}) {
+	if conn == nil {
+		return
+	}
+	go func() {
+		payload["event"] = eventType
+
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return
+		}
+
+		ch, err := conn.Channel()
+		if err != nil {
+			return
+		}
+		defer ch.Close()
+
+		_, err = ch.QueueDeclare("security", true, false, false, false, nil)
+		if err != nil {
+			return
+		}
+
+		_ = ch.PublishWithContext(
+			context.Background(),
+			"",
+			"security",
+			false,
+			false,
+			amqp.Publishing{
+				ContentType: "application/json",
+				Body:        body,
+			},
+		)
+	}()
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -33,6 +33,9 @@ var ErrUnauthorized = errors.New("unauthorized")
 // ErrForbidden is returned when access is denied due to account status.
 var ErrForbidden = errors.New("forbidden")
 
+// ErrAccountLocked is returned when the account is temporarily locked.
+var ErrAccountLocked = errors.New("account locked")
+
 // LoginResult holds the result of a successful login.
 type LoginResult struct {
 	Token      string
@@ -49,7 +52,8 @@ type Login2FARequest struct {
 
 // Login validates credentials, creates a session, and returns a token.
 // If cfg.TwoFactorEnabled is true and password is valid, returns Err2FA without creating session.
-func Login(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, login, password, ip string) (*LoginResult, error) {
+// cacheClient is used for account lock checks; may be nil.
+func Login(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, cacheClient *cache.Client, login, password, ip string) (*LoginResult, error) {
 	login = strings.TrimSpace(login)
 	password = strings.TrimSpace(password)
 
@@ -93,9 +97,26 @@ func Login(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, login, p
 		return nil, fmt.Errorf("%w: Account access denied.", ErrForbidden)
 	}
 
+	// Check account lock (before password verification)
+	if cacheClient != nil {
+		locked, err := cacheClient.IsAccountLocked(ctx, int(userID))
+		if err == nil && locked {
+			return nil, fmt.Errorf("%w: account is temporarily locked", ErrAccountLocked)
+		}
+	}
+
 	// Verify password
 	if err := bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(cfg.PasswordSalt+password)); err != nil {
+		// Increment failed login counter
+		if cacheClient != nil {
+			_ = cacheClient.IncrFailedLogin(ctx, int(userID), cfg.RateLimit.Account.MaxFailedLogins, cfg.RateLimit.Account.LockDurationSec)
+		}
 		return nil, fmt.Errorf("%w: invalid credentials", ErrUnauthorized)
+	}
+
+	// Reset failed login counter on successful password verification
+	if cacheClient != nil {
+		_ = cacheClient.ResetFailedLogin(ctx, int(userID))
 	}
 
 	// 2FA: if enabled, send code and return Err2FA instead of creating session


### PR DESCRIPTION
## Summary

Implements sliding window rate limiting and account brute-force protection.

## Changes

- `internal/cache/redis.go` — SlidingWindowIncr, IsAccountLocked, LockAccount, IncrFailedLogin, ResetFailedLogin
- `internal/middleware/ratelimit.go` — RateLimit middleware (IP + device_uid, async security events)
- `internal/service/auth.go` — account lock check/increment/reset in Login + ErrAccountLocked
- `internal/handler/auth.go` — ErrAccountLocked → 429
- `cmd/main.go` — RateLimit middleware wired to login/register/send-code

## Logic

- Sliding window via Redis INCR+EXPIRE per IP and device_uid
- Block on IP OR device_uid limit exceeded
- Account locked in Redis for LockDurationSec after MaxFailedLogins failures
- Failed login counter resets on successful login
- Security events published async to RabbitMQ security queue
- Fallback to IP-only when X-Device-ID header is absent

## Testing

Builds successfully with `CGO_ENABLED=0 go build ./cmd/main.go`.

Fixes darkrain/auth-service#7