### PR TITLE
feat: email and phone format validation

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -212,6 +212,14 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 			Password: req.Password,
 		})
 		if err != nil {
+			if errors.Is(err, service.ErrInvalidEmail) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email format"})
+				return
+			}
+			if errors.Is(err, service.ErrInvalidPhone) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid phone format. Use international format: +79991234567"})
+				return
+			}
 			if errors.Is(err, service.ErrValidation) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return

--- a/internal/handler/verification.go
+++ b/internal/handler/verification.go
@@ -61,6 +61,10 @@ func SendCode(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 		err := service.SendCode(c.Request.Context(), pool, conn, cfg, req.Recipient, req.DeviceUID)
 		if err != nil {
 			switch {
+			case errors.Is(err, service.ErrInvalidEmail):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email format"})
+			case errors.Is(err, service.ErrInvalidPhone):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid phone format. Use international format: +79991234567"})
 			case errors.Is(err, service.ErrTooManyRequests):
 				c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
 			case errors.Is(err, service.ErrValidation):
@@ -187,6 +191,10 @@ func VerifyLogin2FA(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 // handleVerifyError maps service errors to HTTP responses.
 func handleVerifyError(c *gin.Context, err error) {
 	switch {
+	case errors.Is(err, service.ErrInvalidEmail):
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email format"})
+	case errors.Is(err, service.ErrInvalidPhone):
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid phone format. Use international format: +79991234567"})
 	case errors.Is(err, service.ErrTooManyRequests):
 		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
 	case errors.Is(err, service.ErrValidation):

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/darkrain/auth-service/internal/config"
+	"github.com/darkrain/auth-service/internal/validator"
 	"github.com/jackc/pgx/v5/pgxpool"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"golang.org/x/crypto/bcrypt"
@@ -20,6 +21,12 @@ import (
 
 // ErrValidation is returned when request data is invalid.
 var ErrValidation = errors.New("validation error")
+
+// ErrInvalidEmail is returned when the email format is invalid.
+var ErrInvalidEmail = errors.New("invalid email format")
+
+// ErrInvalidPhone is returned when the phone format is invalid.
+var ErrInvalidPhone = errors.New("invalid phone format")
 
 // ErrAlreadyExists is returned when email/phone is already taken.
 var ErrAlreadyExists = errors.New("already exists")
@@ -299,6 +306,17 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 
 	// 3. Determine login type
 	isEmail := strings.Contains(req.Login, "@")
+
+	// 3a. Validate format
+	if isEmail {
+		if !validator.IsValidEmail(req.Login) {
+			return ErrInvalidEmail
+		}
+	} else {
+		if !validator.IsValidPhone(req.Login) {
+			return ErrInvalidPhone
+		}
+	}
 
 	// 4. Uniqueness check
 	if pool != nil {

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/darkrain/auth-service/internal/config"
+	"github.com/darkrain/auth-service/internal/validator"
 	"github.com/jackc/pgx/v5/pgxpool"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -30,6 +31,17 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 	}
 
 	isEmail := strings.Contains(recipient, "@")
+
+	// Validate format
+	if isEmail {
+		if !validator.IsValidEmail(recipient) {
+			return ErrInvalidEmail
+		}
+	} else {
+		if !validator.IsValidPhone(recipient) {
+			return ErrInvalidPhone
+		}
+	}
 
 	// Find user_id by recipient
 	var userID int64
@@ -153,6 +165,18 @@ func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, rec
 
 	if pool == nil {
 		return nil
+	}
+
+	// Validate recipient format
+	isEmail := strings.Contains(recipient, "@")
+	if isEmail {
+		if !validator.IsValidEmail(recipient) {
+			return ErrInvalidEmail
+		}
+	} else {
+		if !validator.IsValidPhone(recipient) {
+			return ErrInvalidPhone
+		}
 	}
 
 	var storedCode string

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,0 +1,20 @@
+package validator
+
+import "regexp"
+
+var (
+	// emailRegex matches RFC 5322 subset: user@domain.tld
+	emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+	// phoneRegex matches E.164: starts with +, then 6-14 digits (total 7-15 chars)
+	phoneRegex = regexp.MustCompile(`^\+[1-9]\d{6,14}$`)
+)
+
+// IsValidEmail returns true if s is a valid email address (RFC 5322 subset).
+func IsValidEmail(s string) bool {
+	return emailRegex.MatchString(s)
+}
+
+// IsValidPhone returns true if s is a valid phone number in E.164 format (+79991234567).
+func IsValidPhone(s string) bool {
+	return phoneRegex.MatchString(s)
+}

--- a/tests/integration/register_test.go
+++ b/tests/integration/register_test.go
@@ -105,3 +105,63 @@ func TestRegister_EmptyPassword(t *testing.T) {
 		t.Fatalf("expected 400 for empty password, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestRegister_InvalidEmail(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]string{
+		"login":    "notanemail",
+		"password": "Password1",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid email, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["error"] == nil {
+		t.Errorf("expected error field in response")
+	}
+}
+
+func TestRegister_InvalidEmailMissingAt(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]string{
+		"login":    "@domain.com",
+		"password": "Password1",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid email @domain.com, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegister_InvalidPhone_NoPlus(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]string{
+		"login":    "89991234567",
+		"password": "Password1",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid phone without +, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["error"] == nil {
+		t.Errorf("expected error field in response")
+	}
+}
+
+func TestRegister_InvalidPhone_TooShort(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]string{
+		"login":    "+7",
+		"password": "Password1",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for too short phone, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/tests/integration/verify_test.go
+++ b/tests/integration/verify_test.go
@@ -151,6 +151,49 @@ func TestVerifyPhone_Success(t *testing.T) {
 	}
 }
 
+func TestSendCode_InvalidEmail(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/send-code", map[string]string{
+		"recipient":  "notanemail",
+		"device_uid": "some-device",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid email in send-code, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["error"] == nil {
+		t.Errorf("expected error field in response")
+	}
+}
+
+func TestSendCode_InvalidPhone(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/send-code", map[string]string{
+		"recipient":  "89991234567",
+		"device_uid": "some-device",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid phone in send-code, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSendCode_Garbage(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/send-code", map[string]string{
+		"recipient":  "not-valid!!!",
+		"device_uid": "some-device",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for garbage recipient in send-code, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestVerifyEmail_AfterVerify_CanLogin(t *testing.T) {
 	truncateTables(t)
 


### PR DESCRIPTION
## Summary

Adds strict format validation for email and phone inputs.

## Changes

- `internal/validator/validator.go` — IsValidEmail (RFC 5322 regexp), IsValidPhone (E.164: +digits, 7-15 chars)
- `internal/service/auth.go` — validates login format in Register
- `internal/service/verification.go` — validates recipient in SendCode and VerifyCode
- `internal/handler/` — maps validation errors to 400 responses
- Integration tests for invalid formats

## Validation rules

- Email: `user@domain.tld` (RFC 5322 subset)
- Phone: E.164 format `+79991234567` (starts with +, 7-15 digits)

Fixes darkrain/auth-service#19