### PR TITLE
security: pre-release fixes (CRIT-1, CRIT-2, HIGH-2..5, MED-1)

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -23,6 +23,7 @@
   "RmqExchangeKind": "direct",
   "SessionTTLDays": 30,
   "TwoFactorEnabled": false,
+  "TrustedProxies": ["127.0.0.1"],
   "RateLimit": {
     "IP": {
       "LoginMaxAttempts": 5,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,6 +109,17 @@ func main() {
 	// HTTP server
 	r := gin.Default()
 
+	// HIGH-4: configure trusted proxies from config
+	if len(cfg.TrustedProxies) > 0 {
+		if err := r.SetTrustedProxies(cfg.TrustedProxies); err != nil {
+			log.Printf("WARNING: SetTrustedProxies: %v", err)
+		}
+	} else {
+		if err := r.SetTrustedProxies([]string{"127.0.0.1"}); err != nil {
+			log.Printf("WARNING: SetTrustedProxies: %v", err)
+		}
+	}
+
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok", "version": Version})
 	})
@@ -132,8 +143,6 @@ func main() {
 			0, 0,
 			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
 		handler.SendCode(pgPool, rmqConn, cfg))
-	r.POST("/auth/verify/email", handler.VerifyEmail(pgPool, cfg))
-	r.POST("/auth/verify/phone", handler.VerifyPhone(pgPool, cfg))
 	r.POST("/auth/login/verify-2fa", handler.VerifyLogin2FA(pgPool, cfg))
 
 	// Protected routes (require valid session token)
@@ -146,6 +155,18 @@ func main() {
 	apiKeys.POST("", handler.CreateAPIKey(pgPool))
 	apiKeys.GET("", handler.ListAPIKeys(pgPool))
 	apiKeys.DELETE("/:id", handler.RevokeAPIKey(pgPool, cacheClient))
+
+	// CRIT-2 + HIGH-2: verify endpoints require auth and have rate limiting
+	authRequired.POST("/auth/verify/email",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/verify/email",
+			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.VerifyEmail(pgPool, cfg))
+	authRequired.POST("/auth/verify/phone",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/verify/phone",
+			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.VerifyPhone(pgPool, cfg))
 
 	// Authenticated user info
 	authRequired.GET("/auth/me", handler.Me())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	RateLimit             RateLimit `json:"RateLimit"`
 	SessionTTLDays        int       `json:"SessionTTLDays"`
 	TwoFactorEnabled      bool      `json:"TwoFactorEnabled"`
+	TrustedProxies        []string  `json:"TrustedProxies"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/db/seed.go
+++ b/internal/db/seed.go
@@ -11,7 +11,7 @@ import (
 
 func Seed(pool *pgxpool.Pool, cfg *config.Config) error {
 	// Hash password (must use same salt prefix as Login service: cfg.PasswordSalt + password)
-	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.PasswordSalt+cfg.SystemUserPassword), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.PasswordSalt+cfg.SystemUserPassword), 12)
 	if err != nil {
 		return fmt.Errorf("seed: hash password: %w", err)
 	}

--- a/internal/handler/verification.go
+++ b/internal/handler/verification.go
@@ -82,13 +82,16 @@ func SendCode(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 // VerifyEmail handles POST /auth/verify/email
 //
 //	@Summary		Verify email address
-//	@Description	Verifies a user's email address using a code sent to them.
+//	@Description	Verifies a user's email address using a code sent to them. Requires Bearer token.
 //	@Tags			verification
 //	@Accept			json
 //	@Produce		json
+//	@Security		BearerAuth
 //	@Param			request	body		verifyCodeRequest	true	"Email, code and device UID"
 //	@Success		200		{object}	messageResponse
 //	@Failure		400		{object}	errorResponse
+//	@Failure		401		{object}	errorResponse
+//	@Failure		403		{object}	errorResponse
 //	@Failure		404		{object}	errorResponse
 //	@Failure		429		{object}	errorResponse
 //	@Failure		500		{object}	errorResponse
@@ -101,7 +104,18 @@ func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 			return
 		}
 
-		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "email")
+		// Get authenticated user ID from context (set by Auth middleware)
+		var userID int64
+		if uid, exists := c.Get("user_id"); exists {
+			switch v := uid.(type) {
+			case int:
+				userID = int64(v)
+			case int64:
+				userID = v
+			}
+		}
+
+		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "email", userID)
 		if err != nil {
 			handleVerifyError(c, err)
 			return
@@ -114,13 +128,16 @@ func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 // VerifyPhone handles POST /auth/verify/phone
 //
 //	@Summary		Verify phone number
-//	@Description	Verifies a user's phone number using a code sent to them.
+//	@Description	Verifies a user's phone number using a code sent to them. Requires Bearer token.
 //	@Tags			verification
 //	@Accept			json
 //	@Produce		json
+//	@Security		BearerAuth
 //	@Param			request	body		verifyCodeRequest	true	"Phone, code and device UID"
 //	@Success		200		{object}	messageResponse
 //	@Failure		400		{object}	errorResponse
+//	@Failure		401		{object}	errorResponse
+//	@Failure		403		{object}	errorResponse
 //	@Failure		404		{object}	errorResponse
 //	@Failure		429		{object}	errorResponse
 //	@Failure		500		{object}	errorResponse
@@ -133,7 +150,18 @@ func VerifyPhone(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 			return
 		}
 
-		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "phone")
+		// Get authenticated user ID from context (set by Auth middleware)
+		var userID int64
+		if uid, exists := c.Get("user_id"); exists {
+			switch v := uid.(type) {
+			case int:
+				userID = int64(v)
+			case int64:
+				userID = v
+			}
+		}
+
+		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "phone", userID)
 		if err != nil {
 			handleVerifyError(c, err)
 			return
@@ -199,6 +227,8 @@ func handleVerifyError(c *gin.Context, err error) {
 		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
 	case errors.Is(err, service.ErrValidation):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrForbidden):
+		c.JSON(http.StatusForbidden, gin.H{"error": strings.TrimPrefix(err.Error(), "forbidden: ")})
 	case errors.Is(err, service.ErrNotFound):
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 	case errors.Is(err, service.ErrUnauthorized):

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -95,6 +95,11 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 			} else {
 				ttl = 24 * time.Hour // default TTL for API keys without expiry
 			}
+			// Cap TTL at 15 minutes so bans/role changes take effect quickly (HIGH-5)
+			const maxCacheTTL = 15 * time.Minute
+			if ttl > maxCacheTTL {
+				ttl = maxCacheTTL
+			}
 			if ttl > 0 {
 				_ = cacheClient.SetSession(c.Request.Context(), token, sd, ttl)
 			}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -207,15 +207,32 @@ func LoginVerify2FA(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config,
 	isEmail := strings.Contains(req.Login, "@")
 
 	var userID int64
+	var verifyStatus string
 	if pool != nil {
 		var query string
 		if isEmail {
-			query = `SELECT id FROM users WHERE email = $1 LIMIT 1`
+			query = `SELECT id, verify_status FROM users WHERE email = $1 LIMIT 1`
 		} else {
-			query = `SELECT id FROM users WHERE phone = $1 LIMIT 1`
+			query = `SELECT id, verify_status FROM users WHERE phone = $1 LIMIT 1`
 		}
-		if err := pool.QueryRow(ctx, query, req.Login).Scan(&userID); err != nil {
+		if err := pool.QueryRow(ctx, query, req.Login).Scan(&userID, &verifyStatus); err != nil {
 			return nil, fmt.Errorf("%w: user not found", ErrNotFound)
+		}
+	}
+
+	// Check verify_status
+	switch verifyStatus {
+	case "verified":
+		// OK
+	case "registered":
+		return nil, fmt.Errorf("%w: Account not verified. Please verify your email or phone.", ErrForbidden)
+	case "banned":
+		return nil, fmt.Errorf("%w: Account is banned.", ErrForbidden)
+	case "deleted":
+		return nil, fmt.Errorf("%w: Account not found.", ErrForbidden)
+	default:
+		if verifyStatus != "" {
+			return nil, fmt.Errorf("%w: Account access denied.", ErrForbidden)
 		}
 	}
 
@@ -335,9 +352,14 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 		}
 	}
 
+	// 5. Validate password max length
+	if err := validator.ValidatePasswordLength(req.Password); err != nil {
+		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
+	}
+
 	// 5. Hash password: bcrypt(salt + password)
 	saltedPassword := cfg.PasswordSalt + req.Password
-	hash, err := bcrypt.GenerateFromPassword([]byte(saltedPassword), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(saltedPassword), 12)
 	if err != nil {
 		return fmt.Errorf("bcrypt: %w", err)
 	}

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -32,7 +32,7 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 
 	isEmail := strings.Contains(recipient, "@")
 
-	// Validate format
+	// Validate format (IsValidEmail/IsValidPhone also enforce max length)
 	if isEmail {
 		if !validator.IsValidEmail(recipient) {
 			return ErrInvalidEmail
@@ -159,7 +159,8 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 
 // VerifyCode checks a verification code for the given recipient+deviceUID.
 // verifyType must be "email" or "phone".
-func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, recipient, code, deviceUID, verifyType string) error {
+// userID is the authenticated user's ID; the recipient must match their email/phone.
+func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, recipient, code, deviceUID, verifyType string, userID int64) error {
 	recipient = strings.TrimSpace(recipient)
 	code = strings.TrimSpace(code)
 
@@ -176,6 +177,23 @@ func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, rec
 	} else {
 		if !validator.IsValidPhone(recipient) {
 			return ErrInvalidPhone
+		}
+	}
+
+	// Verify that the recipient belongs to the authenticated user (CRIT-2)
+	if userID > 0 {
+		var dbValue string
+		var ownerQuery string
+		if isEmail {
+			ownerQuery = `SELECT COALESCE(email,'') FROM users WHERE id=$1 LIMIT 1`
+		} else {
+			ownerQuery = `SELECT COALESCE(phone,'') FROM users WHERE id=$1 LIMIT 1`
+		}
+		if err := pool.QueryRow(ctx, ownerQuery, userID).Scan(&dbValue); err != nil {
+			return fmt.Errorf("%w: user not found", ErrNotFound)
+		}
+		if dbValue != recipient {
+			return fmt.Errorf("%w: recipient does not match authenticated user", ErrForbidden)
 		}
 	}
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,6 +1,18 @@
 package validator
 
-import "regexp"
+import (
+	"errors"
+	"regexp"
+)
+
+// MaxPasswordLength is the maximum allowed password length.
+const MaxPasswordLength = 128
+
+// MaxEmailLength is the maximum allowed email length (RFC 5321).
+const MaxEmailLength = 254
+
+// MaxPhoneLength is the maximum allowed phone length (E.164 max = 15 digits + '+').
+const MaxPhoneLength = 16
 
 var (
 	// emailRegex matches RFC 5322 subset: user@domain.tld
@@ -11,10 +23,24 @@ var (
 
 // IsValidEmail returns true if s is a valid email address (RFC 5322 subset).
 func IsValidEmail(s string) bool {
+	if len(s) > MaxEmailLength {
+		return false
+	}
 	return emailRegex.MatchString(s)
 }
 
 // IsValidPhone returns true if s is a valid phone number in E.164 format (+79991234567).
 func IsValidPhone(s string) bool {
+	if len(s) > MaxPhoneLength {
+		return false
+	}
 	return phoneRegex.MatchString(s)
+}
+
+// ValidatePasswordLength returns an error if the password exceeds MaxPasswordLength.
+func ValidatePasswordLength(s string) error {
+	if len(s) > MaxPasswordLength {
+		return errors.New("password too long (max 128 characters)")
+	}
+	return nil
 }

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -94,13 +94,23 @@ func TestMain(m *testing.M) {
 			0, 0,
 			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
 		handler.SendCode(pool, nil, cfg))
-	r.POST("/auth/verify/email", handler.VerifyEmail(pool, cfg))
-	r.POST("/auth/verify/phone", handler.VerifyPhone(pool, cfg))
 	r.POST("/auth/login/verify-2fa", handler.VerifyLogin2FA(pool, cfg))
 
 	// Protected routes
 	authRequired := r.Group("/")
 	authRequired.Use(middleware.Auth(pool, testCache))
+
+	// CRIT-2 + HIGH-2: verify endpoints require auth and have rate limiting
+	authRequired.POST("/auth/verify/email",
+		middleware.RateLimit(testCache, nil, "/auth/verify/email",
+			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.VerifyEmail(pool, cfg))
+	authRequired.POST("/auth/verify/phone",
+		middleware.RateLimit(testCache, nil, "/auth/verify/phone",
+			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.VerifyPhone(pool, cfg))
 
 	// API key management (admin and system only)
 	apiKeys := authRequired.Group("/auth/api-keys")
@@ -217,7 +227,40 @@ func getConfirmCode(t *testing.T, recipient, deviceUID string) string {
 	return code
 }
 
+// createTempSession inserts a temporary session for an unverified user and returns the token.
+// Used for testing verify endpoints that now require authentication.
+func createTempSession(t *testing.T, recipient string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	// Find user ID
+	var userID int64
+	var query string
+	if strings.Contains(recipient, "@") {
+		query = `SELECT id FROM users WHERE email=$1 LIMIT 1`
+	} else {
+		query = `SELECT id FROM users WHERE phone=$1 LIMIT 1`
+	}
+	if err := testPool.QueryRow(ctx, query, recipient).Scan(&userID); err != nil {
+		t.Fatalf("createTempSession: user not found for %s: %v", recipient, err)
+	}
+
+	// Insert a temporary session (30 days expiry)
+	token := fmt.Sprintf("test-temp-session-%d", userID)
+	_, err := testPool.Exec(ctx,
+		`INSERT INTO sessions (user_id, token, expire_date, auth_type, ip, blocked)
+		 VALUES ($1, $2, NOW() + INTERVAL '30 days', 'password', '127.0.0.1', false)
+		 ON CONFLICT DO NOTHING`,
+		userID, token,
+	)
+	if err != nil {
+		t.Fatalf("createTempSession: insert session: %v", err)
+	}
+	return token
+}
+
 // verifyUser sends a code and verifies the recipient via email or phone endpoint.
+// CRIT-2: verify endpoints now require an auth token.
 func verifyUser(t *testing.T, recipient, deviceUID string) {
 	t.Helper()
 
@@ -238,11 +281,14 @@ func verifyUser(t *testing.T, recipient, deviceUID string) {
 		endpoint = "/auth/verify/email"
 	}
 
+	// Create a temporary session so we can authenticate the verify call
+	token := createTempSession(t, recipient)
+
 	w = doRequest("POST", endpoint, map[string]string{
 		"recipient":  recipient,
 		"code":       code,
 		"device_uid": deviceUID,
-	}, "")
+	}, token)
 	if w.Code != http.StatusOK {
 		t.Fatalf("verifyUser verify(%s): expected 200, got %d: %s", recipient, w.Code, w.Body.String())
 	}

--- a/tests/integration/verify_test.go
+++ b/tests/integration/verify_test.go
@@ -62,12 +62,15 @@ func TestVerifyEmail_Success(t *testing.T) {
 	// Get code from DB
 	code := getConfirmCode(t, login, deviceUID)
 
+	// CRIT-2: verify now requires auth token
+	token := createTempSession(t, login)
+
 	// Verify
 	w = doRequest("POST", "/auth/verify/email", map[string]string{
 		"recipient":  login,
 		"code":       code,
 		"device_uid": deviceUID,
-	}, "")
+	}, token)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -92,12 +95,15 @@ func TestVerifyEmail_WrongCode(t *testing.T) {
 		t.Fatalf("send-code: expected 200, got %d", w.Code)
 	}
 
+	// CRIT-2: verify now requires auth token
+	token := createTempSession(t, login)
+
 	// Use wrong code
 	w = doRequest("POST", "/auth/verify/email", map[string]string{
 		"recipient":  login,
 		"code":       "000000",
 		"device_uid": deviceUID,
-	}, "")
+	}, token)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for wrong code, got %d: %s", w.Code, w.Body.String())
@@ -107,11 +113,15 @@ func TestVerifyEmail_WrongCode(t *testing.T) {
 func TestVerifyEmail_CodeNotFound(t *testing.T) {
 	truncateTables(t)
 
+	// CRIT-2: verify now requires auth token; use the system user token for this test
+	// (testing that a code-not-found error is returned, not auth failure)
+	systemToken := loginSystemUser(t)
+
 	w := doRequest("POST", "/auth/verify/email", map[string]string{
-		"recipient":  "nocode@example.com",
+		"recipient":  testCfg.SystemUserEmail,
 		"code":       "123456",
 		"device_uid": "no-device",
-	}, "")
+	}, systemToken)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for missing code, got %d: %s", w.Code, w.Body.String())
@@ -139,12 +149,15 @@ func TestVerifyPhone_Success(t *testing.T) {
 	// Get code from DB
 	code := getConfirmCode(t, login, deviceUID)
 
+	// CRIT-2: verify now requires auth token
+	token := createTempSession(t, login)
+
 	// Verify
 	w = doRequest("POST", "/auth/verify/phone", map[string]string{
 		"recipient":  login,
 		"code":       code,
 		"device_uid": deviceUID,
-	}, "")
+	}, token)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())


### PR DESCRIPTION
## Security Fixes

Addresses all critical and high severity findings from the pre-release security audit.

## Changes

- **CRIT-1**: `LoginVerify2FA` now checks `verify_status` before issuing session
- **CRIT-2**: `/auth/verify/email` and `/auth/verify/phone` now require Bearer token; validates recipient ownership
- **HIGH-2**: Rate limiting applied to verify endpoints
- **HIGH-3**: bcrypt cost raised from 10 → 12
- **HIGH-4**: `gin.SetTrustedProxies()` configured from `TrustedProxies` config field
- **HIGH-5**: Redis session cache TTL capped at 15 minutes
- **MED-1**: Max length validation: password ≤128, email ≤254, phone ≤15

## Testing

All integration tests pass (including updated verify tests that now require auth token).

Fixes darkrain/auth-service#21