### PR TITLE
feat: registration token for email/phone verification

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -22,6 +22,7 @@
   "RmqExchangeName": "mail",
   "RmqExchangeKind": "direct",
   "SessionTTLDays": 30,
+  "RegistrationTokenTTLMin": 30,
   "TwoFactorEnabled": false,
   "TrustedProxies": ["127.0.0.1"],
   "RateLimit": {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,12 +161,12 @@ func main() {
 		middleware.RateLimit(cacheClient, rmqConn, "/auth/verify/email",
 			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
 			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
-		handler.VerifyEmail(pgPool, cfg))
+		handler.VerifyEmail(pgPool, cfg, cacheClient))
 	authRequired.POST("/auth/verify/phone",
 		middleware.RateLimit(cacheClient, rmqConn, "/auth/verify/phone",
 			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
 			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
-		handler.VerifyPhone(pgPool, cfg))
+		handler.VerifyPhone(pgPool, cfg, cacheClient))
 
 	// Authenticated user info
 	authRequired.GET("/auth/me", handler.Me())

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -18,6 +18,7 @@ type SessionData struct {
 	Phone        string `json:"phone"`
 	Role         string `json:"role"`
 	VerifyStatus string `json:"verify_status"`
+	AuthType     string `json:"auth_type"`
 }
 
 // Client wraps a redis.Client with session-specific helpers.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,7 +63,8 @@ type Config struct {
 	RmqExchangeName       string    `json:"RmqExchangeName"`
 	RmqExchangeKind       string    `json:"RmqExchangeKind"`
 	RateLimit             RateLimit `json:"RateLimit"`
-	SessionTTLDays        int       `json:"SessionTTLDays"`
+	SessionTTLDays           int       `json:"SessionTTLDays"`
+	RegistrationTokenTTLMin  int       `json:"RegistrationTokenTTLMin"`
 	TwoFactorEnabled      bool      `json:"TwoFactorEnabled"`
 	TrustedProxies        []string  `json:"TrustedProxies"`
 }

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -38,6 +38,12 @@ type messageResponse struct {
 	Message string `json:"message" example:"Operation successful"`
 }
 
+type registerResponse struct {
+	Message           string `json:"message" example:"Registration successful. Please verify your email/phone."`
+	RegistrationToken string `json:"registration_token" example:"a3f2c1...hex64"`
+	ExpiresIn         int    `json:"expires_in" example:"1800"`
+}
+
 type errorResponse struct {
 	Error string `json:"error" example:"error description"`
 }
@@ -181,12 +187,12 @@ func Me() gin.HandlerFunc {
 // Register handles POST /auth/register
 //
 //	@Summary		Register a new user
-//	@Description	Creates a new user account. Login can be an email address or a phone number. A verification code will be sent to the provided contact.
+//	@Description	Creates a new user account. Login can be an email address or a phone number. Returns a short-lived registration_token to authenticate verification calls.
 //	@Tags			auth
 //	@Accept			json
 //	@Produce		json
 //	@Param			request	body		registerRequest	true	"Registration data"
-//	@Success		201		{object}	messageResponse
+//	@Success		201		{object}	registerResponse
 //	@Failure		400		{object}	errorResponse
 //	@Failure		500		{object}	errorResponse
 //	@Router			/auth/register [post]
@@ -207,7 +213,7 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 			loginType = "email"
 		}
 
-		err := service.Register(c.Request.Context(), pool, conn, cfg, service.RegisterRequest{
+		result, err := service.Register(c.Request.Context(), pool, conn, cfg, service.RegisterRequest{
 			Login:    req.Login,
 			Password: req.Password,
 		})
@@ -233,7 +239,9 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 		}
 
 		c.JSON(http.StatusCreated, gin.H{
-			"message": "Registration successful. Please verify your " + loginType + ".",
+			"message":            "Registration successful. Please verify your " + loginType + ".",
+			"registration_token": result.RegistrationToken,
+			"expires_in":         result.ExpiresIn,
 		})
 	}
 }

--- a/internal/handler/verification.go
+++ b/internal/handler/verification.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/darkrain/auth-service/internal/config"
 	"github.com/darkrain/auth-service/internal/service"
 	"github.com/gin-gonic/gin"
@@ -96,7 +97,11 @@ func SendCode(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 //	@Failure		429		{object}	errorResponse
 //	@Failure		500		{object}	errorResponse
 //	@Router			/auth/verify/email [post]
-func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
+func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config, cacheClient ...*cache.Client) gin.HandlerFunc {
+	var cc *cache.Client
+	if len(cacheClient) > 0 {
+		cc = cacheClient[0]
+	}
 	return func(c *gin.Context) {
 		var req verifyCodeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -115,7 +120,7 @@ func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 			}
 		}
 
-		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "email", userID)
+		err := service.VerifyCode(c.Request.Context(), pool, cfg, cc, req.Recipient, req.Code, req.DeviceUID, "email", userID)
 		if err != nil {
 			handleVerifyError(c, err)
 			return
@@ -142,7 +147,11 @@ func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 //	@Failure		429		{object}	errorResponse
 //	@Failure		500		{object}	errorResponse
 //	@Router			/auth/verify/phone [post]
-func VerifyPhone(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
+func VerifyPhone(pool *pgxpool.Pool, cfg *config.Config, cacheClient ...*cache.Client) gin.HandlerFunc {
+	var cc *cache.Client
+	if len(cacheClient) > 0 {
+		cc = cacheClient[0]
+	}
 	return func(c *gin.Context) {
 		var req verifyCodeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -161,7 +170,7 @@ func VerifyPhone(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 			}
 		}
 
-		err := service.VerifyCode(c.Request.Context(), pool, cfg, req.Recipient, req.Code, req.DeviceUID, "phone", userID)
+		err := service.VerifyCode(c.Request.Context(), pool, cfg, cc, req.Recipient, req.Code, req.DeviceUID, "phone", userID)
 		if err != nil {
 			handleVerifyError(c, err)
 			return

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -36,11 +36,20 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 		// 1. Check Redis cache
 		if cacheClient != nil {
 			if sd, err := cacheClient.GetSession(c.Request.Context(), token); err == nil && sd != nil {
+				// Restrict registration tokens
+				if sd.AuthType == "registration" {
+					path := c.FullPath()
+					if path != "/auth/verify/email" && path != "/auth/verify/phone" && path != "/auth/send-code" {
+						c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Registration token can only be used for account verification"})
+						return
+					}
+				}
 				c.Set("user_id", sd.UserID)
 				c.Set("email", sd.Email)
 				c.Set("phone", sd.Phone)
 				c.Set("role", sd.Role)
 				c.Set("verify_status", sd.VerifyStatus)
+				c.Set("auth_type", sd.AuthType)
 				c.Set("token", token)
 				c.Next()
 				return
@@ -54,16 +63,16 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 		}
 
 		var userID int
-		var email, phone, role, verifyStatus string
+		var email, phone, role, verifyStatus, authType string
 		var blocked bool
 		var expireDate *time.Time
 
 		err := pool.QueryRow(c.Request.Context(), `
-			SELECT s.user_id, COALESCE(u.email,''), COALESCE(u.phone,''), u.role, u.verify_status, s.blocked, s.expire_date
+			SELECT s.user_id, COALESCE(u.email,''), COALESCE(u.phone,''), u.role, u.verify_status, s.blocked, s.expire_date, COALESCE(s.auth_type,'')
 			FROM sessions s
 			JOIN users u ON u.id = s.user_id
 			WHERE s.token = $1
-		`, token).Scan(&userID, &email, &phone, &role, &verifyStatus, &blocked, &expireDate)
+		`, token).Scan(&userID, &email, &phone, &role, &verifyStatus, &blocked, &expireDate, &authType)
 
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
@@ -80,6 +89,15 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 			return
 		}
 
+		// Restrict registration tokens to verification endpoints only
+		if authType == "registration" {
+			path := c.FullPath()
+			if path != "/auth/verify/email" && path != "/auth/verify/phone" && path != "/auth/send-code" {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Registration token can only be used for account verification"})
+				return
+			}
+		}
+
 		// 3. Store in Redis cache with TTL = expire_date - now
 		if cacheClient != nil {
 			sd := &cache.SessionData{
@@ -88,6 +106,7 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 				Phone:        phone,
 				Role:         role,
 				VerifyStatus: verifyStatus,
+				AuthType:     authType,
 			}
 			var ttl time.Duration
 			if expireDate != nil {
@@ -110,6 +129,7 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 		c.Set("phone", phone)
 		c.Set("role", role)
 		c.Set("verify_status", verifyStatus)
+		c.Set("auth_type", authType)
 		c.Set("token", token)
 
 		c.Next()

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -306,19 +306,26 @@ type RegisterRequest struct {
 	Password string
 }
 
+// RegisterResult holds the result of a successful registration.
+type RegisterResult struct {
+	RegistrationToken string
+	ExpiresIn         int
+}
+
 // Register validates, hashes password, inserts user and publishes a verification event.
-func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config, req RegisterRequest) error {
+// Returns a short-lived registration token the client can use to authenticate verify calls.
+func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config, req RegisterRequest) (*RegisterResult, error) {
 	// 1. Basic field validation
 	if strings.TrimSpace(req.Login) == "" {
-		return fmt.Errorf("%w: login (email or phone) is required", ErrValidation)
+		return nil, fmt.Errorf("%w: login (email or phone) is required", ErrValidation)
 	}
 	if strings.TrimSpace(req.Password) == "" {
-		return fmt.Errorf("%w: password is required", ErrValidation)
+		return nil, fmt.Errorf("%w: password is required", ErrValidation)
 	}
 
 	// 2. Password complexity
 	if err := validatePassword(req.Password, cfg); err != nil {
-		return err
+		return nil, err
 	}
 
 	// 3. Determine login type
@@ -327,11 +334,11 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 	// 3a. Validate format
 	if isEmail {
 		if !validator.IsValidEmail(req.Login) {
-			return ErrInvalidEmail
+			return nil, ErrInvalidEmail
 		}
 	} else {
 		if !validator.IsValidPhone(req.Login) {
-			return ErrInvalidPhone
+			return nil, ErrInvalidPhone
 		}
 	}
 
@@ -345,23 +352,23 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 			query = `SELECT EXISTS(SELECT 1 FROM users WHERE phone = $1)`
 		}
 		if err := pool.QueryRow(ctx, query, req.Login).Scan(&exists); err != nil {
-			return fmt.Errorf("db: uniqueness check: %w", err)
+			return nil, fmt.Errorf("db: uniqueness check: %w", err)
 		}
 		if exists {
-			return fmt.Errorf("%w: %s is already registered", ErrAlreadyExists, req.Login)
+			return nil, fmt.Errorf("%w: %s is already registered", ErrAlreadyExists, req.Login)
 		}
 	}
 
 	// 5. Validate password max length
 	if err := validator.ValidatePasswordLength(req.Password); err != nil {
-		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
+		return nil, fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
 	// 5. Hash password: bcrypt(salt + password)
 	saltedPassword := cfg.PasswordSalt + req.Password
 	hash, err := bcrypt.GenerateFromPassword([]byte(saltedPassword), 12)
 	if err != nil {
-		return fmt.Errorf("bcrypt: %w", err)
+		return nil, fmt.Errorf("bcrypt: %w", err)
 	}
 
 	// 6. Insert user
@@ -374,11 +381,35 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 			insertQuery = `INSERT INTO users (phone, password, role, verify_status) VALUES ($1, $2, 'user', 'registered') RETURNING id`
 		}
 		if err := pool.QueryRow(ctx, insertQuery, req.Login, string(hash)).Scan(&userID); err != nil {
-			return fmt.Errorf("db: insert user: %w", err)
+			return nil, fmt.Errorf("db: insert user: %w", err)
 		}
 	}
 
-	// 7. Publish verification event to RabbitMQ
+	// 6b. Generate registration token (short-lived session for email/phone verification)
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, fmt.Errorf("token generation: %w", err)
+	}
+	registrationToken := hex.EncodeToString(tokenBytes)
+
+	ttlMin := cfg.RegistrationTokenTTLMin
+	if ttlMin <= 0 {
+		ttlMin = 30
+	}
+	expireDate := time.Now().Add(time.Duration(ttlMin) * time.Minute)
+	expiresIn := ttlMin * 60
+
+	if pool != nil {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO sessions (user_id, token, expire_date, auth_type, ip, blocked) VALUES ($1, $2, $3, 'registration', '127.0.0.1', false)`,
+			userID, registrationToken, expireDate,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("db: insert registration session: %w", err)
+		}
+	}
+
+	// 7. Publish verification event to RabbitMQ (best-effort; ignore if broker unavailable)
 	if conn != nil {
 		eventType := "phone_verification"
 		if isEmail {
@@ -397,12 +428,12 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 			UserID:    userID,
 		})
 		if err != nil {
-			return fmt.Errorf("json: marshal event: %w", err)
+			return nil, fmt.Errorf("json: marshal event: %w", err)
 		}
 
 		ch, err := conn.Channel()
 		if err != nil {
-			return fmt.Errorf("broker: open channel: %w", err)
+			return nil, fmt.Errorf("broker: open channel: %w", err)
 		}
 		defer ch.Close()
 
@@ -415,7 +446,7 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 			false, // no-wait
 			nil,
 		); err != nil {
-			return fmt.Errorf("broker: declare exchange: %w", err)
+			return nil, fmt.Errorf("broker: declare exchange: %w", err)
 		}
 
 		if err := ch.PublishWithContext(ctx,
@@ -428,11 +459,14 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 				Body:        payload,
 			},
 		); err != nil {
-			return fmt.Errorf("broker: publish: %w", err)
+			return nil, fmt.Errorf("broker: publish: %w", err)
 		}
 	}
 
-	return nil
+	return &RegisterResult{
+		RegistrationToken: registrationToken,
+		ExpiresIn:         expiresIn,
+	}, nil
 }
 
 // validatePassword checks password complexity against config rules.

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/darkrain/auth-service/internal/cache"
 	"github.com/darkrain/auth-service/internal/config"
 	"github.com/darkrain/auth-service/internal/validator"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -160,7 +161,8 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 // VerifyCode checks a verification code for the given recipient+deviceUID.
 // verifyType must be "email" or "phone".
 // userID is the authenticated user's ID; the recipient must match their email/phone.
-func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, recipient, code, deviceUID, verifyType string, userID int64) error {
+// cacheClient is optional; used to purge registration session tokens from Redis.
+func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, cacheClient *cache.Client, recipient, code, deviceUID, verifyType string, userID int64) error {
 	recipient = strings.TrimSpace(recipient)
 	code = strings.TrimSpace(code)
 
@@ -254,6 +256,30 @@ func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, rec
 	)
 	if err != nil {
 		return fmt.Errorf("db: delete confirm_codes: %w", err)
+	}
+
+	// Invalidate all registration tokens for this user
+	if userID > 0 {
+		// Fetch registration session tokens before blocking them (for cache invalidation)
+		if cacheClient != nil {
+			rows, qErr := pool.Query(ctx,
+				`SELECT token FROM sessions WHERE user_id=$1 AND auth_type='registration' AND blocked=false`,
+				userID,
+			)
+			if qErr == nil {
+				defer rows.Close()
+				for rows.Next() {
+					var t string
+					if rows.Scan(&t) == nil {
+						_ = cacheClient.DeleteSession(ctx, t)
+					}
+				}
+			}
+		}
+		_, _ = pool.Exec(ctx,
+			`UPDATE sessions SET blocked=true WHERE user_id=$1 AND auth_type='registration'`,
+			userID,
+		)
 	}
 
 	return nil

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -105,12 +105,12 @@ func TestMain(m *testing.M) {
 		middleware.RateLimit(testCache, nil, "/auth/verify/email",
 			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
 			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
-		handler.VerifyEmail(pool, cfg))
+		handler.VerifyEmail(pool, cfg, testCache))
 	authRequired.POST("/auth/verify/phone",
 		middleware.RateLimit(testCache, nil, "/auth/verify/phone",
 			cfg.RateLimit.IP.LoginMaxAttempts, cfg.RateLimit.IP.LoginWindowSec,
 			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
-		handler.VerifyPhone(pool, cfg))
+		handler.VerifyPhone(pool, cfg, testCache))
 
 	// API key management (admin and system only)
 	apiKeys := authRequired.Group("/auth/api-keys")
@@ -201,7 +201,8 @@ func parseJSON(w *httptest.ResponseRecorder) map[string]interface{} {
 }
 
 // registerUser registers a user via POST /auth/register. Fails test on non-201.
-func registerUser(t *testing.T, login, password string) {
+// Returns the registration_token from the response for use in verify calls.
+func registerUser(t *testing.T, login, password string) string {
 	t.Helper()
 	w := doRequest("POST", "/auth/register", map[string]string{
 		"login":    login,
@@ -210,6 +211,9 @@ func registerUser(t *testing.T, login, password string) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("registerUser(%s): expected 201, got %d: %s", login, w.Code, w.Body.String())
 	}
+	body := parseJSON(w)
+	token, _ := body["registration_token"].(string)
+	return token
 }
 
 // getConfirmCode reads the verification code directly from DB for the given recipient+device.
@@ -260,8 +264,9 @@ func createTempSession(t *testing.T, recipient string) string {
 }
 
 // verifyUser sends a code and verifies the recipient via email or phone endpoint.
-// CRIT-2: verify endpoints now require an auth token.
-func verifyUser(t *testing.T, recipient, deviceUID string) {
+// Uses the registration_token returned by registerUser for authentication.
+// token is the registration_token from registerUser(); if empty, falls back to createTempSession.
+func verifyUser(t *testing.T, recipient, deviceUID string, registrationToken ...string) {
 	t.Helper()
 
 	// Send code
@@ -281,8 +286,13 @@ func verifyUser(t *testing.T, recipient, deviceUID string) {
 		endpoint = "/auth/verify/email"
 	}
 
-	// Create a temporary session so we can authenticate the verify call
-	token := createTempSession(t, recipient)
+	// Use registration token if provided, otherwise fall back to temporary session
+	var token string
+	if len(registrationToken) > 0 && registrationToken[0] != "" {
+		token = registrationToken[0]
+	} else {
+		token = createTempSession(t, recipient)
+	}
 
 	w = doRequest("POST", endpoint, map[string]string{
 		"recipient":  recipient,

--- a/tests/integration/verify_test.go
+++ b/tests/integration/verify_test.go
@@ -214,12 +214,63 @@ func TestVerifyEmail_AfterVerify_CanLogin(t *testing.T) {
 	password := "Password1"
 	deviceUID := "device-verified-login"
 
-	registerUser(t, login, password)
-	verifyUser(t, login, deviceUID)
+	registrationToken := registerUser(t, login, password)
+	verifyUser(t, login, deviceUID, registrationToken)
 
 	// Now login should succeed
 	token := loginUser(t, login, password)
 	if token == "" {
 		t.Fatal("expected non-empty token after verification")
+	}
+}
+
+// TestRegistrationToken_CannotAccessMe verifies that a registration token
+// cannot be used to access protected non-verify endpoints (GET /auth/me → 403).
+func TestRegistrationToken_CannotAccessMe(t *testing.T) {
+	truncateTables(t)
+
+	login := "regtoken_me@example.com"
+	password := "Password1"
+
+	registrationToken := registerUser(t, login, password)
+	if registrationToken == "" {
+		t.Fatal("expected registration_token in register response")
+	}
+
+	w := doRequest("GET", "/auth/me", nil, registrationToken)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for registration token on /auth/me, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["error"] == nil {
+		t.Errorf("expected error field in 403 response")
+	}
+}
+
+// TestRegistrationToken_InvalidatedAfterVerification verifies that after successful
+// email verification the registration token is blocked and cannot be reused.
+func TestRegistrationToken_InvalidatedAfterVerification(t *testing.T) {
+	truncateTables(t)
+
+	login := "regtoken_inv@example.com"
+	password := "Password1"
+	deviceUID := "device-regtoken-inv"
+
+	registrationToken := registerUser(t, login, password)
+	if registrationToken == "" {
+		t.Fatal("expected registration_token in register response")
+	}
+
+	// Verify using the registration token
+	verifyUser(t, login, deviceUID, registrationToken)
+
+	// After verification the registration token should be blocked (401)
+	w := doRequest("POST", "/auth/verify/email", map[string]string{
+		"recipient":  login,
+		"code":       "000000",
+		"device_uid": deviceUID,
+	}, registrationToken)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 after registration token invalidation, got %d: %s", w.Code, w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

Adds `registration_token` to the register response so clients can authenticate verify calls.

## Flow

1. `POST /auth/register` → returns `registration_token` (TTL: 30min, auth_type=registration)
2. Client uses token to call `POST /auth/verify/email` or `/auth/verify/phone`
3. On success: registration token is invalidated
4. Client calls `POST /auth/login` normally

## Changes

- `internal/service/auth.go` — Register() creates registration session, returns token
- `internal/handler/auth.go` — returns registration_token + expires_in in response
- `internal/middleware/auth.go` — registration tokens restricted to verify/send-code endpoints
- `internal/service/verification.go` — invalidates registration token on verify success
- `internal/config/config.go` — RegistrationTokenTTLMin field
- `internal/cache/redis.go` — SessionData.AuthType field added
- Tests updated to use real registration flow

## Testing

All integration tests pass.

Fixes darkrain/auth-service#23