### PR TITLE
security: final pre-release fixes (NEW-1, NEW-2, MINOR-1, MINOR-2)

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -30,7 +30,9 @@
       "LoginMaxAttempts": 5,
       "LoginWindowSec": 900,
       "RegisterMaxAttempts": 3,
-      "RegisterWindowSec": 3600
+      "RegisterWindowSec": 3600,
+      "SendCodeMaxAttempts": 10,
+      "SendCodeWindowSec": 60
     },
     "Device": {
       "LoginMaxAttempts": 10,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,16 +138,17 @@ func main() {
 			cfg.RateLimit.Device.LoginMaxAttempts, cfg.RateLimit.Device.LoginWindowSec),
 		handler.Login(pgPool, rmqConn, cfg, cacheClient))
 	r.POST("/auth/logout", handler.Logout(pgPool, cacheClient))
-	r.POST("/auth/send-code",
-		middleware.RateLimit(cacheClient, rmqConn, "/auth/send-code",
-			0, 0,
-			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
-		handler.SendCode(pgPool, rmqConn, cfg))
 	r.POST("/auth/login/verify-2fa", handler.VerifyLogin2FA(pgPool, cfg))
 
 	// Protected routes (require valid session token)
 	authRequired := r.Group("/")
 	authRequired.Use(middleware.Auth(pgPool, cacheClient))
+
+	authRequired.POST("/auth/send-code",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/send-code",
+			cfg.RateLimit.IP.SendCodeMaxAttempts, cfg.RateLimit.IP.SendCodeWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.SendCode(pgPool, rmqConn, cfg))
 
 	// API key management (admin and system only)
 	apiKeys := authRequired.Group("/auth/api-keys")

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -71,16 +71,24 @@ func (c *Client) DeleteSession(ctx context.Context, token string) error {
 	return c.rdb.Del(ctx, sessionKey(token)).Err()
 }
 
+// luaIncrExpire atomically increments a key and sets its TTL on first increment.
+// This prevents a race condition where EXPIRE could be lost if the process crashes
+// between INCR and EXPIRE, causing the counter to never expire.
+var luaIncrExpire = redis.NewScript(`
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[1]))
+end
+return current
+`)
+
 // SlidingWindowIncr increments a sliding window counter in Redis.
-// Uses INCR + EXPIRE pattern: if key is new (count==1), set TTL to windowSec.
+// Uses an atomic Lua script to set TTL on first increment, preventing counter leak.
 // Returns the current count after increment.
 func (c *Client) SlidingWindowIncr(ctx context.Context, key string, windowSec int) (int64, error) {
-	count, err := c.rdb.Incr(ctx, key).Result()
+	count, err := luaIncrExpire.Run(ctx, c.rdb, []string{key}, windowSec).Int64()
 	if err != nil {
 		return 0, err
-	}
-	if count == 1 {
-		_ = c.rdb.Expire(ctx, key, time.Duration(windowSec)*time.Second).Err()
 	}
 	return count, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ type RateLimitIP struct {
 	LoginWindowSec      int `json:"LoginWindowSec"`
 	RegisterMaxAttempts int `json:"RegisterMaxAttempts"`
 	RegisterWindowSec   int `json:"RegisterWindowSec"`
+	SendCodeMaxAttempts int `json:"SendCodeMaxAttempts"`
+	SendCodeWindowSec   int `json:"SendCodeWindowSec"`
 }
 
 type RateLimitDevice struct {

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -231,7 +231,7 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 				return
 			}
 			if errors.Is(err, service.ErrAlreadyExists) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Login already registered"})
 				return
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -29,7 +29,7 @@ var ErrInvalidEmail = errors.New("invalid email format")
 var ErrInvalidPhone = errors.New("invalid phone format")
 
 // ErrAlreadyExists is returned when email/phone is already taken.
-var ErrAlreadyExists = errors.New("already exists")
+var ErrAlreadyExists = errors.New("login already registered")
 
 // ErrNotFound is returned when the user is not found.
 var ErrNotFound = errors.New("not found")
@@ -355,7 +355,7 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 			return nil, fmt.Errorf("db: uniqueness check: %w", err)
 		}
 		if exists {
-			return nil, fmt.Errorf("%w: %s is already registered", ErrAlreadyExists, req.Login)
+			return nil, ErrAlreadyExists
 		}
 	}
 

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -89,16 +89,18 @@ func TestMain(m *testing.M) {
 			cfg.RateLimit.Device.LoginMaxAttempts, cfg.RateLimit.Device.LoginWindowSec),
 		handler.Login(pool, nil, cfg, testCache))
 	r.POST("/auth/logout", handler.Logout(pool, testCache))
-	r.POST("/auth/send-code",
-		middleware.RateLimit(testCache, nil, "/auth/send-code",
-			0, 0,
-			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
-		handler.SendCode(pool, nil, cfg))
 	r.POST("/auth/login/verify-2fa", handler.VerifyLogin2FA(pool, cfg))
 
 	// Protected routes
 	authRequired := r.Group("/")
 	authRequired.Use(middleware.Auth(pool, testCache))
+
+	// NEW-2: /auth/send-code moved to authRequired group
+	authRequired.POST("/auth/send-code",
+		middleware.RateLimit(testCache, nil, "/auth/send-code",
+			cfg.RateLimit.IP.SendCodeMaxAttempts, cfg.RateLimit.IP.SendCodeWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.SendCode(pool, nil, cfg))
 
 	// CRIT-2 + HIGH-2: verify endpoints require auth and have rate limiting
 	authRequired.POST("/auth/verify/email",
@@ -269,11 +271,19 @@ func createTempSession(t *testing.T, recipient string) string {
 func verifyUser(t *testing.T, recipient, deviceUID string, registrationToken ...string) {
 	t.Helper()
 
-	// Send code
+	// Use registration token if provided, otherwise fall back to temporary session
+	var authToken string
+	if len(registrationToken) > 0 && registrationToken[0] != "" {
+		authToken = registrationToken[0]
+	} else {
+		authToken = createTempSession(t, recipient)
+	}
+
+	// NEW-2: /auth/send-code now requires auth token
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  recipient,
 		"device_uid": deviceUID,
-	}, "")
+	}, authToken)
 	if w.Code != http.StatusOK {
 		t.Fatalf("verifyUser send-code(%s): expected 200, got %d: %s", recipient, w.Code, w.Body.String())
 	}
@@ -286,19 +296,11 @@ func verifyUser(t *testing.T, recipient, deviceUID string, registrationToken ...
 		endpoint = "/auth/verify/email"
 	}
 
-	// Use registration token if provided, otherwise fall back to temporary session
-	var token string
-	if len(registrationToken) > 0 && registrationToken[0] != "" {
-		token = registrationToken[0]
-	} else {
-		token = createTempSession(t, recipient)
-	}
-
 	w = doRequest("POST", endpoint, map[string]string{
 		"recipient":  recipient,
 		"code":       code,
 		"device_uid": deviceUID,
-	}, token)
+	}, authToken)
 	if w.Code != http.StatusOK {
 		t.Fatalf("verifyUser verify(%s): expected 200, got %d: %s", recipient, w.Code, w.Body.String())
 	}

--- a/tests/integration/verify_test.go
+++ b/tests/integration/verify_test.go
@@ -12,12 +12,12 @@ func TestSendCode_Success(t *testing.T) {
 	password := "Password1"
 	deviceUID := "device-sendcode"
 
-	registerUser(t, login, password)
+	registrationToken := registerUser(t, login, password)
 
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  login,
 		"device_uid": deviceUID,
-	}, "")
+	}, registrationToken)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -28,13 +28,34 @@ func TestSendCode_Success(t *testing.T) {
 	}
 }
 
+// TestSendCode_NoToken verifies that /auth/send-code requires authentication.
+func TestSendCode_NoToken(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/send-code", map[string]string{
+		"recipient":  "test@example.com",
+		"device_uid": "some-device",
+	}, "")
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing token on /auth/send-code, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["error"] == nil {
+		t.Errorf("expected error field in 401 response")
+	}
+}
+
 func TestSendCode_EmptyRecipient(t *testing.T) {
 	truncateTables(t)
+
+	// NEW-2: /auth/send-code now requires auth; use system user token to test validation
+	systemToken := loginSystemUser(t)
 
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  "",
 		"device_uid": "some-device",
-	}, "")
+	}, systemToken)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for empty recipient, got %d: %s", w.Code, w.Body.String())
@@ -48,13 +69,13 @@ func TestVerifyEmail_Success(t *testing.T) {
 	password := "Password1"
 	deviceUID := "device-verify-email"
 
-	registerUser(t, login, password)
+	registrationToken := registerUser(t, login, password)
 
-	// Send code
+	// NEW-2: /auth/send-code now requires auth; use registration token
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  login,
 		"device_uid": deviceUID,
-	}, "")
+	}, registrationToken)
 	if w.Code != http.StatusOK {
 		t.Fatalf("send-code: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -63,7 +84,7 @@ func TestVerifyEmail_Success(t *testing.T) {
 	code := getConfirmCode(t, login, deviceUID)
 
 	// CRIT-2: verify now requires auth token
-	token := createTempSession(t, login)
+	token := registrationToken
 
 	// Verify
 	w = doRequest("POST", "/auth/verify/email", map[string]string{
@@ -84,19 +105,19 @@ func TestVerifyEmail_WrongCode(t *testing.T) {
 	password := "Password1"
 	deviceUID := "device-wrong-code"
 
-	registerUser(t, login, password)
+	registrationToken := registerUser(t, login, password)
 
-	// Send code
+	// NEW-2: /auth/send-code now requires auth; use registration token
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  login,
 		"device_uid": deviceUID,
-	}, "")
+	}, registrationToken)
 	if w.Code != http.StatusOK {
 		t.Fatalf("send-code: expected 200, got %d", w.Code)
 	}
 
 	// CRIT-2: verify now requires auth token
-	token := createTempSession(t, login)
+	token := registrationToken
 
 	// Use wrong code
 	w = doRequest("POST", "/auth/verify/email", map[string]string{
@@ -135,13 +156,13 @@ func TestVerifyPhone_Success(t *testing.T) {
 	password := "Password1"
 	deviceUID := "device-verify-phone"
 
-	registerUser(t, login, password)
+	registrationToken := registerUser(t, login, password)
 
-	// Send code
+	// NEW-2: /auth/send-code now requires auth; use registration token
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  login,
 		"device_uid": deviceUID,
-	}, "")
+	}, registrationToken)
 	if w.Code != http.StatusOK {
 		t.Fatalf("send-code: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -150,7 +171,7 @@ func TestVerifyPhone_Success(t *testing.T) {
 	code := getConfirmCode(t, login, deviceUID)
 
 	// CRIT-2: verify now requires auth token
-	token := createTempSession(t, login)
+	token := registrationToken
 
 	// Verify
 	w = doRequest("POST", "/auth/verify/phone", map[string]string{
@@ -167,10 +188,13 @@ func TestVerifyPhone_Success(t *testing.T) {
 func TestSendCode_InvalidEmail(t *testing.T) {
 	truncateTables(t)
 
+	// NEW-2: /auth/send-code now requires auth; use system user token to test validation
+	systemToken := loginSystemUser(t)
+
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  "notanemail",
 		"device_uid": "some-device",
-	}, "")
+	}, systemToken)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid email in send-code, got %d: %s", w.Code, w.Body.String())
@@ -184,10 +208,13 @@ func TestSendCode_InvalidEmail(t *testing.T) {
 func TestSendCode_InvalidPhone(t *testing.T) {
 	truncateTables(t)
 
+	// NEW-2: /auth/send-code now requires auth; use system user token to test validation
+	systemToken := loginSystemUser(t)
+
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  "89991234567",
 		"device_uid": "some-device",
-	}, "")
+	}, systemToken)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid phone in send-code, got %d: %s", w.Code, w.Body.String())
@@ -197,10 +224,13 @@ func TestSendCode_InvalidPhone(t *testing.T) {
 func TestSendCode_Garbage(t *testing.T) {
 	truncateTables(t)
 
+	// NEW-2: /auth/send-code now requires auth; use system user token to test validation
+	systemToken := loginSystemUser(t)
+
 	w := doRequest("POST", "/auth/send-code", map[string]string{
 		"recipient":  "not-valid!!!",
 		"device_uid": "some-device",
-	}, "")
+	}, systemToken)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for garbage recipient in send-code, got %d: %s", w.Code, w.Body.String())


### PR DESCRIPTION
## Final Security Fixes

Last batch of security improvements before v1.0.0 release.

## Changes

- **NEW-1**: IP rate limiting on `/auth/send-code` — config fields `SendCodeIPMaxAttempts` / `SendCodeIPWindowSec` (default 10/60s)
- **NEW-2**: `/auth/send-code` moved to `authRequired` group — registration token whitelist now actually enforced
- **MINOR-1**: `ErrAlreadyExists` no longer includes email/phone in error response
- **MINOR-2**: Redis `INCR+EXPIRE` replaced with atomic Lua script — prevents counter leak on Expire failure

## Testing

All integration tests pass.

Fixes darkrain/auth-service#25