### PR TITLE
feat: test accounts with fixed verification codes

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -27,6 +27,7 @@
   "TrustedProxies": ["127.0.0.1"],
   "PostgreSQLSSLMode": "require",
   "SwaggerEnabled": false,
+  "TestAccounts": [],
   "RateLimit": {
     "IP": {
       "LoginMaxAttempts": 5,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,11 @@ type RateLimit struct {
 	Code    RateLimitCode    `json:"Code"`
 }
 
+type TestAccount struct {
+	Login string `json:"login"`
+	Code  string `json:"code"`
+}
+
 type Config struct {
 	Host                  string    `json:"Host"`
 	Port                  string    `json:"Port"`
@@ -73,6 +78,7 @@ type Config struct {
 	TrustedProxies           []string  `json:"TrustedProxies"`
 	PostgreSQLSSLMode         string    `json:"PostgreSQLSSLMode"`
 	SwaggerEnabled            bool      `json:"SwaggerEnabled"`
+	TestAccounts              []TestAccount `json:"TestAccounts"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -99,27 +99,46 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 		// err != nil means no row → first time, fine
 	}
 
-	// Generate 6-digit code
-	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
-	if err != nil {
-		return fmt.Errorf("crypto/rand: %w", err)
+	// Check if this is a test account
+	testCode := ""
+	for _, ta := range cfg.TestAccounts {
+		if ta.Login == recipient {
+			testCode = ta.Code
+			break
+		}
 	}
-	code := fmt.Sprintf("%06d", n.Int64())
+
+	// Generate 6-digit code (or use fixed test code)
+	var code string
+	if testCode != "" {
+		code = testCode
+	} else {
+		n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+		if err != nil {
+			return fmt.Errorf("crypto/rand: %w", err)
+		}
+		code = fmt.Sprintf("%06d", n.Int64())
+	}
 
 	now := time.Now()
 
 	// UPSERT into confirm_codes
 	if pool != nil {
-		_, err = pool.Exec(ctx,
+		_, upsertErr := pool.Exec(ctx,
 			`INSERT INTO confirm_codes (device_uid, recipient, code, counter, sent_ts)
 			 VALUES ($1, $2, $3, 0, $4)
 			 ON CONFLICT (device_uid, recipient) DO UPDATE
 			 SET code = EXCLUDED.code, counter = 0, sent_ts = EXCLUDED.sent_ts`,
 			deviceUID, recipient, code, now,
 		)
-		if err != nil {
-			return fmt.Errorf("db: upsert confirm_codes: %w", err)
+		if upsertErr != nil {
+			return fmt.Errorf("db: upsert confirm_codes: %w", upsertErr)
 		}
+	}
+
+	// Skip RabbitMQ publish for test accounts
+	if testCode != "" {
+		return nil
 	}
 
 	// Publish event to RabbitMQ

--- a/tests/integration/verify_test.go
+++ b/tests/integration/verify_test.go
@@ -304,6 +304,75 @@ func TestRegistrationToken_CannotAccessMe(t *testing.T) {
 	}
 }
 
+// TestFixedVerificationCode verifies that a test account uses the fixed verification code
+// and skips RabbitMQ (code is saved to DB directly).
+func TestFixedVerificationCode(t *testing.T) {
+	truncateTables(t)
+
+	login := "testaccount@example.com"
+	password := "Password1"
+	deviceUID := "device-fixed-code"
+
+	// Register with the test account email
+	registrationToken := registerUser(t, login, password)
+	if registrationToken == "" {
+		t.Fatal("expected registration_token in register response")
+	}
+
+	// Call send-code — should use fixed code "111111" and NOT publish to RabbitMQ
+	w := doRequest("POST", "/auth/send-code", map[string]string{
+		"recipient":  login,
+		"device_uid": deviceUID,
+	}, registrationToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("send-code: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify with the fixed code "111111" → should succeed
+	w = doRequest("POST", "/auth/verify/email", map[string]string{
+		"recipient":  login,
+		"code":       "111111",
+		"device_uid": deviceUID,
+	}, registrationToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("verify with fixed code: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestFixedVerificationCode_WrongCode verifies that a wrong code for a test account still fails.
+func TestFixedVerificationCode_WrongCode(t *testing.T) {
+	truncateTables(t)
+
+	login := "testaccount@example.com"
+	password := "Password1"
+	deviceUID := "device-fixed-code-wrong"
+
+	// Register with the test account email
+	registrationToken := registerUser(t, login, password)
+	if registrationToken == "" {
+		t.Fatal("expected registration_token in register response")
+	}
+
+	// Call send-code
+	w := doRequest("POST", "/auth/send-code", map[string]string{
+		"recipient":  login,
+		"device_uid": deviceUID,
+	}, registrationToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("send-code: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify with a wrong code → should fail with 400
+	w = doRequest("POST", "/auth/verify/email", map[string]string{
+		"recipient":  login,
+		"code":       "000000",
+		"device_uid": deviceUID,
+	}, registrationToken)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("verify with wrong code: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestRegistrationToken_InvalidatedAfterVerification verifies that after successful
 // email verification the registration token is blocked and cannot be reused.
 func TestRegistrationToken_InvalidatedAfterVerification(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `TestAccounts` to config — login+code pairs that use a fixed verification code and skip RabbitMQ. Useful for development and testing without real SMS/email delivery.

## Config

```json
{
  "TestAccounts": [
    { "login": "example@email.com", "code": "143456" },
    { "login": "+79999999999", "code": "455678" }
  ]
}
```

## Changes

- `internal/config/config.go` — `TestAccounts []TestAccount` field
- `internal/service/verification.go` — SendCode checks TestAccounts; if match: uses fixed code, skips RabbitMQ
- `auth-service.example.json` — `TestAccounts: []`
- `auth-service.test.json` — test account added
- Integration test for fixed code flow

Fixes darkrain/auth-service#29