### PR TITLE
fix: TestAccounts audit improvements

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,5 +122,16 @@ func (c *Config) Validate() error {
 	if c.RateLimit.Account.MaxFailedLogins == 0 {
 		log.Printf("WARNING: config: RateLimit.Account.MaxFailedLogins is 0 (account lockout disabled)")
 	}
+	if len(c.TestAccounts) > 0 {
+		log.Printf("WARNING: TestAccounts is non-empty (%d accounts configured) — ensure this is not a production deployment", len(c.TestAccounts))
+	}
+	for i, ta := range c.TestAccounts {
+		if ta.Login == "" {
+			return fmt.Errorf("config: TestAccounts[%d].login must not be empty", i)
+		}
+		if ta.Code == "" {
+			return fmt.Errorf("config: TestAccounts[%d].code must not be empty", i)
+		}
+	}
 	return nil
 }

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -102,7 +102,7 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 	// Check if this is a test account
 	testCode := ""
 	for _, ta := range cfg.TestAccounts {
-		if ta.Login == recipient {
+		if strings.EqualFold(ta.Login, recipient) {
 			testCode = ta.Code
 			break
 		}


### PR DESCRIPTION
## Changes

- **Case-insensitive** `Login` comparison in `SendCode` (`strings.EqualFold`)
- **Startup WARNING** log when `TestAccounts` is non-empty
- **Validation** in `config.Validate()` — empty `Login` or `Code` returns error

Fixes darkrain/auth-service#31