### PR TITLE
feat: add error codes to all API error responses

### DIFF
--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -32,18 +32,18 @@ func CreateAPIKey(pool *pgxpool.Pool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userIDVal, exists := c.Get("user_id")
 		if !exists {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "not authenticated"))
 			return
 		}
 		userID, ok := userIDVal.(int)
 		if !ok {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid user id"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "invalid user id"))
 			return
 		}
 
 		key, err := service.CreateAPIKey(c.Request.Context(), pool, userID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create API key"})
+			c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "failed to create API key"))
 			return
 		}
 
@@ -70,18 +70,18 @@ func ListAPIKeys(pool *pgxpool.Pool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userIDVal, exists := c.Get("user_id")
 		if !exists {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "not authenticated"))
 			return
 		}
 		userID, ok := userIDVal.(int)
 		if !ok {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid user id"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "invalid user id"))
 			return
 		}
 
 		keys, err := service.ListAPIKeys(c.Request.Context(), pool, userID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list API keys"})
+			c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "failed to list API keys"))
 			return
 		}
 
@@ -107,28 +107,28 @@ func RevokeAPIKey(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc
 	return func(c *gin.Context) {
 		userIDVal, exists := c.Get("user_id")
 		if !exists {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "not authenticated"))
 			return
 		}
 		userID, ok := userIDVal.(int)
 		if !ok {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid user id"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "invalid user id"))
 			return
 		}
 
 		keyIDStr := c.Param("id")
 		keyID, err := strconv.Atoi(keyIDStr)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid key id"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid key id"))
 			return
 		}
 
 		if err := service.RevokeAPIKey(c.Request.Context(), pool, cacheClient, keyID, userID); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})
+				c.JSON(http.StatusNotFound, errResp(CodeUserNotFound, "API key not found"))
 				return
 			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to revoke API key"})
+			c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "failed to revoke API key"))
 			return
 		}
 

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -46,6 +46,7 @@ type registerResponse struct {
 
 type errorResponse struct {
 	Error string `json:"error" example:"error description"`
+	Code  string `json:"code" example:"ERR_INVALID_REQUEST"`
 }
 
 // Login handles POST /auth/login
@@ -69,7 +70,7 @@ func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config, cacheC
 	return func(c *gin.Context) {
 		var req loginRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
 			return
 		}
 
@@ -88,20 +89,32 @@ func Login(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config, cacheC
 				c.JSON(http.StatusAccepted, gin.H{
 					"message":      "Code sent to your email/phone. Please verify.",
 					"requires_2fa": true,
+					"code":         Code2FARequired,
 				})
 			case errors.Is(err, service.ErrAccountLocked):
-				c.JSON(http.StatusTooManyRequests, gin.H{"error": "Account temporarily locked due to too many failed attempts"})
+				c.JSON(http.StatusTooManyRequests, errResp(CodeAccountLocked, "Account temporarily locked due to too many failed attempts"))
 			case errors.Is(err, service.ErrValidation):
-				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, err.Error()))
 			case errors.Is(err, service.ErrNotFound):
-				c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+				c.JSON(http.StatusNotFound, errResp(CodeUserNotFound, "user not found"))
 			case errors.Is(err, service.ErrForbidden):
 				msg := strings.TrimPrefix(err.Error(), "forbidden: ")
-				c.JSON(http.StatusForbidden, gin.H{"error": msg})
+				var errCode string
+				switch {
+				case strings.Contains(msg, "not verified"):
+					errCode = CodeNotVerified
+				case strings.Contains(msg, "banned"):
+					errCode = CodeBanned
+				case strings.Contains(msg, "deleted"):
+					errCode = CodeDeleted
+				default:
+					errCode = CodeForbidden
+				}
+				c.JSON(http.StatusForbidden, errResp(errCode, msg))
 			case errors.Is(err, service.ErrUnauthorized):
-				c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+				c.JSON(http.StatusUnauthorized, errResp(CodeInvalidCredentials, "invalid credentials"))
 			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+				c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "internal server error"))
 			}
 			return
 		}
@@ -129,18 +142,18 @@ func Logout(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 		if !strings.HasPrefix(authHeader, "Bearer ") {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization token required"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "authorization token required"))
 			return
 		}
 		token := strings.TrimPrefix(authHeader, "Bearer ")
 		token = strings.TrimSpace(token)
 		if token == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization token required"})
+			c.JSON(http.StatusUnauthorized, errResp(CodeUnauthorized, "authorization token required"))
 			return
 		}
 
 		if err := service.Logout(c.Request.Context(), pool, cacheClient, token); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "internal server error"))
 			return
 		}
 
@@ -200,7 +213,7 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 	return func(c *gin.Context) {
 		var req registerRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
 			return
 		}
 
@@ -219,22 +232,22 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidEmail) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email format"})
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidEmail, "Invalid email format"))
 				return
 			}
 			if errors.Is(err, service.ErrInvalidPhone) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid phone format. Use international format: +79991234567"})
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidPhone, "Invalid phone format. Use international format: +79991234567"))
 				return
 			}
 			if errors.Is(err, service.ErrValidation) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, err.Error()))
 				return
 			}
 			if errors.Is(err, service.ErrAlreadyExists) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Login already registered"})
+				c.JSON(http.StatusBadRequest, errResp(CodeLoginExists, "Login already registered"))
 				return
 			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "internal server error"))
 			return
 		}
 

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -1,0 +1,35 @@
+package handler
+
+import "github.com/gin-gonic/gin"
+
+// Error codes for API responses
+const (
+	CodeInvalidRequest     = "ERR_INVALID_REQUEST"
+	CodeInvalidEmail       = "ERR_INVALID_EMAIL"
+	CodeInvalidPhone       = "ERR_INVALID_PHONE"
+	CodeInvalidCredentials = "ERR_INVALID_CREDENTIALS"
+	CodeUserNotFound       = "ERR_USER_NOT_FOUND"
+	CodeLoginExists        = "ERR_LOGIN_EXISTS"
+	CodeNotVerified        = "ERR_NOT_VERIFIED"
+	CodeBanned             = "ERR_BANNED"
+	CodeDeleted            = "ERR_DELETED"
+	CodeRoleReserved       = "ERR_ROLE_RESERVED"
+	CodeRoleInvalid        = "ERR_ROLE_INVALID"
+	CodePasswordTooShort   = "ERR_PASSWORD_TOO_SHORT"
+	CodePasswordTooLong    = "ERR_PASSWORD_TOO_LONG"
+	Code2FARequired        = "ERR_2FA_REQUIRED"
+	CodeCodeInvalid        = "ERR_CODE_INVALID"
+	CodeCodeNotFound       = "ERR_CODE_NOT_FOUND"
+	CodeRecipientMismatch  = "ERR_RECIPIENT_MISMATCH"
+	CodeTooManyRequests    = "ERR_TOO_MANY_REQUESTS"
+	CodeAccountLocked      = "ERR_ACCOUNT_LOCKED"
+	CodeUnauthorized       = "ERR_UNAUTHORIZED"
+	CodeForbidden          = "ERR_FORBIDDEN"
+	CodeInternal           = "ERR_INTERNAL"
+	CodeRegistrationToken  = "ERR_REGISTRATION_TOKEN"
+)
+
+// errResp returns a gin.H with error message and code
+func errResp(code, message string) gin.H {
+	return gin.H{"error": message, "code": code}
+}

--- a/internal/handler/verification.go
+++ b/internal/handler/verification.go
@@ -47,7 +47,7 @@ func SendCode(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 	return func(c *gin.Context) {
 		var req sendCodeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
 			return
 		}
 
@@ -55,7 +55,7 @@ func SendCode(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 		req.DeviceUID = strings.TrimSpace(req.DeviceUID)
 
 		if req.Recipient == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "recipient is required"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "recipient is required"))
 			return
 		}
 
@@ -74,19 +74,19 @@ func SendCode(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrInvalidEmail):
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email format"})
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidEmail, "Invalid email format"))
 			case errors.Is(err, service.ErrInvalidPhone):
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid phone format. Use international format: +79991234567"})
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidPhone, "Invalid phone format. Use international format: +79991234567"))
 			case errors.Is(err, service.ErrTooManyRequests):
-				c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+				c.JSON(http.StatusTooManyRequests, errResp(CodeTooManyRequests, err.Error()))
 			case errors.Is(err, service.ErrValidation):
-				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, err.Error()))
 			case errors.Is(err, service.ErrForbiddenRecipient):
-				c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+				c.JSON(http.StatusForbidden, errResp(CodeRecipientMismatch, err.Error()))
 			case errors.Is(err, service.ErrForbidden):
-				c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+				c.JSON(http.StatusForbidden, errResp(CodeForbidden, "forbidden"))
 			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+				c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "internal server error"))
 			}
 			return
 		}
@@ -120,7 +120,7 @@ func VerifyEmail(pool *pgxpool.Pool, cfg *config.Config, cacheClient ...*cache.C
 	return func(c *gin.Context) {
 		var req verifyCodeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
 			return
 		}
 
@@ -170,7 +170,7 @@ func VerifyPhone(pool *pgxpool.Pool, cfg *config.Config, cacheClient ...*cache.C
 	return func(c *gin.Context) {
 		var req verifyCodeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
 			return
 		}
 
@@ -213,7 +213,7 @@ func VerifyLogin2FA(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req verifyLogin2FARequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
 			return
 		}
 
@@ -244,20 +244,20 @@ func VerifyLogin2FA(pool *pgxpool.Pool, cfg *config.Config) gin.HandlerFunc {
 func handleVerifyError(c *gin.Context, err error) {
 	switch {
 	case errors.Is(err, service.ErrInvalidEmail):
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email format"})
+		c.JSON(http.StatusBadRequest, errResp(CodeInvalidEmail, "Invalid email format"))
 	case errors.Is(err, service.ErrInvalidPhone):
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid phone format. Use international format: +79991234567"})
+		c.JSON(http.StatusBadRequest, errResp(CodeInvalidPhone, "Invalid phone format. Use international format: +79991234567"))
 	case errors.Is(err, service.ErrTooManyRequests):
-		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+		c.JSON(http.StatusTooManyRequests, errResp(CodeTooManyRequests, err.Error()))
 	case errors.Is(err, service.ErrValidation):
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, err.Error()))
 	case errors.Is(err, service.ErrForbidden):
-		c.JSON(http.StatusForbidden, gin.H{"error": strings.TrimPrefix(err.Error(), "forbidden: ")})
+		c.JSON(http.StatusForbidden, errResp(CodeForbidden, strings.TrimPrefix(err.Error(), "forbidden: ")))
 	case errors.Is(err, service.ErrNotFound):
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		c.JSON(http.StatusNotFound, errResp(CodeCodeNotFound, err.Error()))
 	case errors.Is(err, service.ErrUnauthorized):
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid verification code"})
+		c.JSON(http.StatusBadRequest, errResp(CodeCodeInvalid, "invalid verification code"))
 	default:
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "internal server error"))
 	}
 }

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -10,6 +10,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// Error code constants for middleware responses
+const (
+	codeUnauthorized      = "ERR_UNAUTHORIZED"
+	codeForbidden         = "ERR_FORBIDDEN"
+	codeRegistrationToken = "ERR_REGISTRATION_TOKEN"
+)
+
 // Auth middleware validates Bearer token or X-API-Key header.
 // It checks the Redis cache first; on cache miss it queries the sessions table,
 // then caches the result with TTL = expire_date - now.
@@ -29,7 +36,7 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 		}
 
 		if token == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authorization token required"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authorization token required", "code": codeUnauthorized})
 			return
 		}
 
@@ -40,7 +47,7 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 				if sd.AuthType == "registration" {
 					path := c.FullPath()
 					if path != "/auth/verify/email" && path != "/auth/verify/phone" && path != "/auth/send-code" {
-						c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Registration token can only be used for account verification"})
+						c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Registration token can only be used for account verification", "code": codeRegistrationToken})
 						return
 					}
 				}
@@ -58,7 +65,7 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 
 		// 2. Cache miss — query DB
 		if pool == nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "database unavailable"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "database unavailable", "code": codeUnauthorized})
 			return
 		}
 
@@ -75,17 +82,17 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 		`, token).Scan(&userID, &email, &phone, &role, &verifyStatus, &blocked, &expireDate, &authType)
 
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token", "code": codeUnauthorized})
 			return
 		}
 
 		if blocked {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has been revoked"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has been revoked", "code": codeUnauthorized})
 			return
 		}
 
 		if expireDate != nil && time.Now().After(*expireDate) {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has expired"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has expired", "code": codeUnauthorized})
 			return
 		}
 
@@ -93,7 +100,7 @@ func Auth(pool *pgxpool.Pool, cacheClient *cache.Client) gin.HandlerFunc {
 		if authType == "registration" {
 			path := c.FullPath()
 			if path != "/auth/verify/email" && path != "/auth/verify/phone" && path != "/auth/send-code" {
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Registration token can only be used for account verification"})
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Registration token can only be used for account verification", "code": codeRegistrationToken})
 				return
 			}
 		}
@@ -146,18 +153,18 @@ func RequireRole(roles ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		role, exists := c.Get("role")
 		if !exists {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "not authenticated", "code": codeUnauthorized})
 			return
 		}
 
 		roleStr, ok := role.(string)
 		if !ok {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid role"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid role", "code": codeUnauthorized})
 			return
 		}
 
 		if _, ok := allowed[roleStr]; !ok {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "access denied: insufficient role"})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "access denied: insufficient role", "code": codeForbidden})
 			return
 		}
 

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -13,6 +13,8 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
+const codeTooManyRequests = "ERR_TOO_MANY_REQUESTS"
+
 // RateLimit returns a Gin middleware that applies sliding window rate limiting
 // by IP and optionally by device_uid (X-Device-ID header).
 //
@@ -51,7 +53,7 @@ func RateLimit(cacheClient *cache.Client, conn *amqp.Connection, endpoint string
 					"count":    count,
 					"ts":       time.Now().Unix(),
 				})
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "Too many requests. Try again later."})
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "Too many requests. Try again later.", "code": codeTooManyRequests})
 				return
 			}
 		}
@@ -69,7 +71,7 @@ func RateLimit(cacheClient *cache.Client, conn *amqp.Connection, endpoint string
 					"count":     count,
 					"ts":        time.Now().Unix(),
 				})
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "Too many requests. Try again later."})
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "Too many requests. Try again later.", "code": codeTooManyRequests})
 				return
 			}
 		}


### PR DESCRIPTION
## Изменения

- `internal/handler/errors.go` — константы кодов ошибок + хелпер `errResp()`
- Все handlers обновлены: `gin.H{"error": ...}` → `errResp(CodeXxx, ...)`
- 202 ответ 2FA теперь содержит `"code": "ERR_2FA_REQUIRED"`
- Middleware обновлены с кодами ошибок
- Swagger `errorResponse` добавлено поле `code`

Fixes darkrain/auth-service#34