### PR TITLE
feat: CORS middleware via AllowedOrigins config

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -25,6 +25,7 @@
   "RegistrationTokenTTLMin": 30,
   "TwoFactorEnabled": false,
   "TrustedProxies": ["127.0.0.1"],
+  "AllowedOrigins": ["https://app.example.com"],
   "PostgreSQLSSLMode": "require",
   "SwaggerEnabled": false,
   "TestAccounts": [],

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,6 +135,31 @@ func main() {
 		}
 	}
 
+	// CORS middleware
+	if len(cfg.AllowedOrigins) > 0 {
+		r.Use(func(c *gin.Context) {
+			origin := c.Request.Header.Get("Origin")
+			allowed := false
+			for _, o := range cfg.AllowedOrigins {
+				if o == "*" || o == origin {
+					allowed = true
+					break
+				}
+			}
+			if allowed {
+				c.Header("Access-Control-Allow-Origin", origin)
+				c.Header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+				c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+				c.Header("Access-Control-Max-Age", "86400")
+			}
+			if c.Request.Method == http.MethodOptions {
+				c.AbortWithStatus(http.StatusNoContent)
+				return
+			}
+			c.Next()
+		})
+	}
+
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok", "version": Version})
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	RegistrationTokenTTLMin  int       `json:"RegistrationTokenTTLMin"`
 	TwoFactorEnabled         bool      `json:"TwoFactorEnabled"`
 	TrustedProxies           []string  `json:"TrustedProxies"`
+	AllowedOrigins           []string  `json:"AllowedOrigins"`
 	PostgreSQLSSLMode         string    `json:"PostgreSQLSSLMode"`
 	SwaggerEnabled            bool      `json:"SwaggerEnabled"`
 	TestAccounts              []TestAccount `json:"TestAccounts"`


### PR DESCRIPTION
## Изменения

- `AllowedOrigins []string` в конфиге
- CORS middleware: поддержка `*` и конкретных origin
- OPTIONS preflight → 204
- Если AllowedOrigins пустой — CORS не включается

Fixes darkrain/auth-service#35