### PR TITLE
feat: configurable roles via AllowedRoles config

### DIFF
--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -29,6 +29,7 @@
   "PostgreSQLSSLMode": "require",
   "SwaggerEnabled": false,
   "TestAccounts": [],
+  "AllowedRoles": ["model", "manager", "agency"],
   "RateLimit": {
     "IP": {
       "LoginMaxAttempts": 5,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ type Config struct {
 	PostgreSQLSSLMode         string    `json:"PostgreSQLSSLMode"`
 	SwaggerEnabled            bool      `json:"SwaggerEnabled"`
 	TestAccounts              []TestAccount `json:"TestAccounts"`
+	AllowedRoles              []string      `json:"AllowedRoles"`
 }
 
 func Load(path string) (*Config, error) {
@@ -134,5 +135,24 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("config: TestAccounts[%d].code must not be empty", i)
 		}
 	}
+	for _, role := range c.AllowedRoles {
+		if role == "admin" || role == "system" {
+			return fmt.Errorf("config: AllowedRoles must not contain reserved role %q", role)
+		}
+	}
 	return nil
+}
+
+// IsValidRole returns true if the given role is a built-in reserved role (admin, system)
+// or is listed in AllowedRoles.
+func (c *Config) IsValidRole(role string) bool {
+	if role == "admin" || role == "system" {
+		return true
+	}
+	for _, r := range c.AllowedRoles {
+		if r == role {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -32,6 +32,7 @@ type login2FAResponse struct {
 type registerRequest struct {
 	Login    string `json:"login" example:"user@example.com"`
 	Password string `json:"password" example:"Secret123!"`
+	Role     string `json:"role" example:"model"`
 }
 
 type messageResponse struct {
@@ -165,7 +166,6 @@ type meResponse struct {
 	ID           int    `json:"id" example:"1"`
 	Email        string `json:"email" example:"user@example.com"`
 	Phone        string `json:"phone" example:"+79001234567"`
-	Role         string `json:"role" example:"user"`
 	VerifyStatus string `json:"verify_status" example:"verified"`
 }
 
@@ -229,6 +229,7 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 		result, err := service.Register(c.Request.Context(), pool, conn, cfg, service.RegisterRequest{
 			Login:    req.Login,
 			Password: req.Password,
+			Role:     req.Role,
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidEmail) {
@@ -239,8 +240,19 @@ func Register(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config) gin
 				c.JSON(http.StatusBadRequest, errResp(CodeInvalidPhone, "Invalid phone format. Use international format: +79991234567"))
 				return
 			}
+			// ErrForbidden check must come before ErrValidation since reserved role returns ErrForbidden
+			if errors.Is(err, service.ErrForbidden) {
+				msg := strings.TrimPrefix(err.Error(), "forbidden: ")
+				c.JSON(http.StatusForbidden, errResp(CodeRoleReserved, msg))
+				return
+			}
 			if errors.Is(err, service.ErrValidation) {
-				c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, err.Error()))
+				msg := err.Error()
+				if strings.Contains(msg, "invalid role") {
+					c.JSON(http.StatusBadRequest, errResp(CodeRoleInvalid, msg))
+					return
+				}
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, msg))
 				return
 			}
 			if errors.Is(err, service.ErrAlreadyExists) {

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -304,6 +304,7 @@ func Logout(ctx context.Context, pool *pgxpool.Pool, cacheClient *cache.Client, 
 type RegisterRequest struct {
 	Login    string
 	Password string
+	Role     string
 }
 
 // RegisterResult holds the result of a successful registration.
@@ -321,6 +322,23 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 	}
 	if strings.TrimSpace(req.Password) == "" {
 		return nil, fmt.Errorf("%w: password is required", ErrValidation)
+	}
+
+	// 1b. Resolve role
+	role := strings.TrimSpace(req.Role)
+	if role == "" {
+		if len(cfg.AllowedRoles) > 0 {
+			role = cfg.AllowedRoles[0]
+		} else {
+			role = "user"
+		}
+	} else {
+		if role == "admin" || role == "system" {
+			return nil, fmt.Errorf("%w: cannot register with reserved role", ErrForbidden)
+		}
+		if !cfg.IsValidRole(role) {
+			return nil, fmt.Errorf("%w: invalid role", ErrValidation)
+		}
 	}
 
 	// 2. Password complexity
@@ -376,11 +394,11 @@ func Register(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 	if pool != nil {
 		var insertQuery string
 		if isEmail {
-			insertQuery = `INSERT INTO users (email, password, role, verify_status) VALUES ($1, $2, 'user', 'registered') RETURNING id`
+			insertQuery = `INSERT INTO users (email, password, role, verify_status) VALUES ($1, $2, $3, 'registered') RETURNING id`
 		} else {
-			insertQuery = `INSERT INTO users (phone, password, role, verify_status) VALUES ($1, $2, 'user', 'registered') RETURNING id`
+			insertQuery = `INSERT INTO users (phone, password, role, verify_status) VALUES ($1, $2, $3, 'registered') RETURNING id`
 		}
-		if err := pool.QueryRow(ctx, insertQuery, req.Login, string(hash)).Scan(&userID); err != nil {
+		if err := pool.QueryRow(ctx, insertQuery, req.Login, string(hash), role).Scan(&userID); err != nil {
 			return nil, fmt.Errorf("db: insert user: %w", err)
 		}
 	}

--- a/tests/integration/register_test.go
+++ b/tests/integration/register_test.go
@@ -165,3 +165,66 @@ func TestRegister_InvalidPhone_TooShort(t *testing.T) {
 		t.Fatalf("expected 400 for too short phone, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestRegister_WithRole_Model(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]interface{}{
+		"login":    "rolemodel@example.com",
+		"password": "Password1",
+		"role":     "model",
+	}, "")
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for role=model, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegister_WithRole_Admin_Forbidden(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]interface{}{
+		"login":    "adminrole@example.com",
+		"password": "Password1",
+		"role":     "admin",
+	}, "")
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for role=admin, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if code, ok := body["code"].(string); !ok || code != "ERR_ROLE_RESERVED" {
+		t.Errorf("expected code ERR_ROLE_RESERVED, got: %s", w.Body.String())
+	}
+}
+
+func TestRegister_WithRole_Unknown_Invalid(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]interface{}{
+		"login":    "unknownrole@example.com",
+		"password": "Password1",
+		"role":     "unknown_role",
+	}, "")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for role=unknown_role, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if code, ok := body["code"].(string); !ok || code != "ERR_ROLE_INVALID" {
+		t.Errorf("expected code ERR_ROLE_INVALID, got: %s", w.Body.String())
+	}
+}
+
+func TestRegister_NoRole_DefaultsToFirstAllowedRole(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequest("POST", "/auth/register", map[string]string{
+		"login":    "norole@example.com",
+		"password": "Password1",
+	}, "")
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for empty role (default), got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Изменения

- `AllowedRoles []string` в конфиге + `IsValidRole()` хелпер
- `Register` принимает опциональное поле `role`
- `admin`/`system` при регистрации → 403 `ERR_ROLE_RESERVED`
- Неизвестная роль → 400 `ERR_ROLE_INVALID`
- Пустая роль → первая из AllowedRoles или `user`
- Интеграционные тесты

Fixes darkrain/auth-service#33