### PR TITLE
feat: восстановление пароля (#39)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -186,6 +186,10 @@ func main() {
 			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
 		handler.VerifyLogin2FA(pgPool, cfg))
 
+	// Password reset (public — no auth required)
+	r.POST("/auth/password/reset-request", handler.ResetRequest(pgPool, rmqConn, cfg, cacheClient))
+	r.POST("/auth/password/reset-confirm", handler.ResetConfirm(pgPool, cfg, cacheClient))
+
 	// Protected routes (require valid session token)
 	authRequired := r.Group("/")
 	authRequired.Use(middleware.Auth(pgPool, cacheClient))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,9 +72,11 @@ type Config struct {
 	RmqExchangeName       string    `json:"RmqExchangeName"`
 	RmqExchangeKind       string    `json:"RmqExchangeKind"`
 	RateLimit             RateLimit `json:"RateLimit"`
-	SessionTTLDays           int       `json:"SessionTTLDays"`
-	RegistrationTokenTTLMin  int       `json:"RegistrationTokenTTLMin"`
-	TwoFactorEnabled         bool      `json:"TwoFactorEnabled"`
+	SessionTTLDays                int       `json:"SessionTTLDays"`
+	RegistrationTokenTTLMin        int       `json:"RegistrationTokenTTLMin"`
+	TwoFactorEnabled               bool      `json:"TwoFactorEnabled"`
+	PasswordResetCodeTTLMin        int       `json:"PasswordResetCodeTTLMin"`
+	PasswordResetRateLimitPerHour  int       `json:"PasswordResetRateLimitPerHour"`
 	TrustedProxies           []string  `json:"TrustedProxies"`
 	AllowedOrigins           []string  `json:"AllowedOrigins"`
 	PostgreSQLSSLMode         string    `json:"PostgreSQLSSLMode"`
@@ -98,6 +100,16 @@ func Load(path string) (*Config, error) {
 	// Default PostgreSQLSSLMode to "disable" if not set (backward compatible)
 	if cfg.PostgreSQLSSLMode == "" {
 		cfg.PostgreSQLSSLMode = "disable"
+	}
+
+	// Default PasswordResetCodeTTLMin
+	if cfg.PasswordResetCodeTTLMin == 0 {
+		cfg.PasswordResetCodeTTLMin = 15
+	}
+
+	// Default PasswordResetRateLimitPerHour
+	if cfg.PasswordResetRateLimitPerHour == 0 {
+		cfg.PasswordResetRateLimitPerHour = 3
 	}
 
 	return &cfg, nil
@@ -135,6 +147,13 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("config: TestAccounts[%d].code must not be empty", i)
 		}
 	}
+	if c.PasswordResetCodeTTLMin <= 0 {
+		return errors.New("config: PasswordResetCodeTTLMin must be greater than 0")
+	}
+	if c.PasswordResetRateLimitPerHour <= 0 {
+		return errors.New("config: PasswordResetRateLimitPerHour must be greater than 0")
+	}
+
 	for _, role := range c.AllowedRoles {
 		if role == "admin" || role == "system" {
 			return fmt.Errorf("config: AllowedRoles must not contain reserved role %q", role)

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -27,6 +27,9 @@ const (
 	CodeForbidden          = "ERR_FORBIDDEN"
 	CodeInternal           = "ERR_INTERNAL"
 	CodeRegistrationToken  = "ERR_REGISTRATION_TOKEN"
+	CodeInvalidCode        = "ERR_INVALID_CODE"
+	CodeCodeExpired        = "ERR_CODE_EXPIRED"
+	CodeWeakPassword       = "ERR_WEAK_PASSWORD"
 )
 
 // errResp returns a gin.H with error message and code

--- a/internal/handler/password_reset.go
+++ b/internal/handler/password_reset.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/darkrain/auth-service/internal/cache"
+	"github.com/darkrain/auth-service/internal/config"
+	"github.com/darkrain/auth-service/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type resetRequestBody struct {
+	Login     string `json:"login"      example:"user@example.com"`
+	DeviceUID string `json:"device_uid" example:"device-uuid-1234"`
+}
+
+type resetConfirmBody struct {
+	Login       string `json:"login"        example:"user@example.com"`
+	Code        string `json:"code"         example:"123456"`
+	DeviceUID   string `json:"device_uid"   example:"device-uuid-1234"`
+	NewPassword string `json:"new_password" example:"NewSecret123!"`
+}
+
+// ResetRequest handles POST /auth/password/reset-request
+//
+//	@Summary		Request password reset code
+//	@Description	Sends a one-time password reset code to the user's email or phone. Always returns 200 to avoid user enumeration.
+//	@Tags			password-reset
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		resetRequestBody	true	"Login and device UID"
+//	@Success		200		{object}	messageResponse
+//	@Failure		400		{object}	errorResponse
+//	@Failure		500		{object}	errorResponse
+//	@Router			/auth/password/reset-request [post]
+func ResetRequest(pool *pgxpool.Pool, conn *amqp.Connection, cfg *config.Config, cacheClient *cache.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req resetRequestBody
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
+			return
+		}
+
+		req.Login = strings.TrimSpace(req.Login)
+		req.DeviceUID = strings.TrimSpace(req.DeviceUID)
+
+		if req.Login == "" {
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "login is required"))
+			return
+		}
+
+		ip := c.GetHeader("X-Real-IP")
+		if ip == "" {
+			ip = c.Request.RemoteAddr
+		}
+
+		// Always return 200 regardless of result (no user enumeration)
+		_ = service.RequestPasswordReset(c.Request.Context(), pool, conn, cfg, cacheClient, req.Login, req.DeviceUID, ip)
+
+		c.JSON(http.StatusOK, gin.H{"message": "If an account with that login exists, a reset code has been sent."})
+	}
+}
+
+// ResetConfirm handles POST /auth/password/reset-confirm
+//
+//	@Summary		Confirm password reset
+//	@Description	Verifies the reset code and sets a new password. Invalidates all existing sessions.
+//	@Tags			password-reset
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		resetConfirmBody	true	"Login, code, device UID and new password"
+//	@Success		200		{object}	messageResponse
+//	@Failure		400		{object}	errorResponse
+//	@Failure		404		{object}	errorResponse
+//	@Failure		500		{object}	errorResponse
+//	@Router			/auth/password/reset-confirm [post]
+func ResetConfirm(pool *pgxpool.Pool, cfg *config.Config, cacheClient *cache.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req resetConfirmBody
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "invalid request body"))
+			return
+		}
+
+		req.Login = strings.TrimSpace(req.Login)
+		req.Code = strings.TrimSpace(req.Code)
+		req.DeviceUID = strings.TrimSpace(req.DeviceUID)
+
+		if req.Login == "" || req.Code == "" || req.NewPassword == "" {
+			c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, "login, code and new_password are required"))
+			return
+		}
+
+		err := service.ConfirmPasswordReset(c.Request.Context(), pool, cfg, cacheClient, req.Login, req.Code, req.DeviceUID, req.NewPassword)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrNotFound):
+				c.JSON(http.StatusNotFound, errResp(CodeUserNotFound, "user not found"))
+			case errors.Is(err, service.ErrCodeExpired):
+				c.JSON(http.StatusBadRequest, errResp(CodeCodeExpired, "reset code has expired"))
+			case errors.Is(err, service.ErrInvalidCode):
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidCode, "invalid reset code"))
+			case errors.Is(err, service.ErrWeakPassword):
+				c.JSON(http.StatusBadRequest, errResp(CodeWeakPassword, strings.TrimPrefix(err.Error(), "validation error: ")))
+			case errors.Is(err, service.ErrValidation):
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidRequest, err.Error()))
+			default:
+				c.JSON(http.StatusInternalServerError, errResp(CodeInternal, "internal server error"))
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "Password reset successfully. Please log in with your new password."})
+	}
+}

--- a/internal/service/password_reset.go
+++ b/internal/service/password_reset.go
@@ -1,0 +1,299 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/darkrain/auth-service/internal/cache"
+	"github.com/darkrain/auth-service/internal/config"
+	"github.com/jackc/pgx/v5/pgxpool"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ErrInvalidCode is returned when the reset code does not match.
+var ErrInvalidCode = errors.New("invalid reset code")
+
+// ErrCodeExpired is returned when the reset code has expired.
+var ErrCodeExpired = errors.New("reset code has expired")
+
+// ErrWeakPassword is returned when the new password fails validation.
+var ErrWeakPassword = errors.New("password does not meet requirements")
+
+const authTypePasswordReset = "password_reset"
+
+// RequestPasswordReset sends a password reset code to the user.
+// Always returns nil regardless of whether the user exists (no enumeration).
+// Rate-limited per IP and per login via Redis.
+func RequestPasswordReset(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	conn *amqp.Connection,
+	cfg *config.Config,
+	cacheClient *cache.Client,
+	login, deviceUID, ip string,
+) error {
+	login = strings.TrimSpace(login)
+	if login == "" {
+		// Silently ignore — no enumeration
+		return nil
+	}
+
+	// Rate limit by IP
+	if cacheClient != nil && cfg.PasswordResetRateLimitPerHour > 0 && ip != "" {
+		ipKey := fmt.Sprintf("rate:password_reset:%s", ip)
+		count, err := cacheClient.SlidingWindowIncr(ctx, ipKey, 3600)
+		if err == nil && count > int64(cfg.PasswordResetRateLimitPerHour) {
+			// Exceeded — silently return nil (no enumeration for reset-request)
+			return nil
+		}
+	}
+
+	// Rate limit by login
+	if cacheClient != nil && cfg.PasswordResetRateLimitPerHour > 0 && login != "" {
+		loginKey := fmt.Sprintf("rate:password_reset:login:%s", strings.ToLower(login))
+		count, err := cacheClient.SlidingWindowIncr(ctx, loginKey, 3600)
+		if err == nil && count > int64(cfg.PasswordResetRateLimitPerHour) {
+			return nil
+		}
+	}
+
+	if pool == nil {
+		return nil
+	}
+
+	// Look up user by email or phone (case-insensitive)
+	isEmail := strings.Contains(login, "@")
+	var userID int64
+	var verifyStatus string
+
+	var query string
+	if isEmail {
+		query = `SELECT id, verify_status FROM users WHERE LOWER(email) = LOWER($1) LIMIT 1`
+	} else {
+		query = `SELECT id, verify_status FROM users WHERE phone = $1 LIMIT 1`
+	}
+	err := pool.QueryRow(ctx, query, login).Scan(&userID, &verifyStatus)
+	if err != nil {
+		// User not found — no enumeration, return nil
+		return nil
+	}
+
+	// Only send code for verified users
+	if verifyStatus != "verified" {
+		return nil
+	}
+
+	// Check if this is a test account
+	testCode := ""
+	for _, ta := range cfg.TestAccounts {
+		if strings.EqualFold(ta.Login, login) {
+			testCode = ta.Code
+			break
+		}
+	}
+
+	// Generate or use fixed code
+	var code string
+	if testCode != "" {
+		code = testCode
+	} else {
+		n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+		if err != nil {
+			return fmt.Errorf("crypto/rand: %w", err)
+		}
+		code = fmt.Sprintf("%06d", n.Int64())
+	}
+
+	now := time.Now()
+	ttlSec := cfg.PasswordResetCodeTTLMin * 60
+
+	// UPSERT into confirm_codes with auth_type='password_reset'
+	_, upsertErr := pool.Exec(ctx,
+		`INSERT INTO confirm_codes (device_uid, recipient, code, counter, sent_ts, auth_type)
+		 VALUES ($1, $2, $3, 0, $4, $5)
+		 ON CONFLICT (device_uid, recipient, auth_type) DO UPDATE
+		 SET code = EXCLUDED.code, counter = 0, sent_ts = EXCLUDED.sent_ts`,
+		deviceUID, login, code, now, authTypePasswordReset,
+	)
+	if upsertErr != nil {
+		return fmt.Errorf("db: upsert confirm_codes: %w", upsertErr)
+	}
+
+	// Skip RabbitMQ for test accounts
+	if testCode != "" {
+		return nil
+	}
+
+	// Publish password_reset event to RabbitMQ
+	if conn != nil {
+		type resetEvent struct {
+			Type      string `json:"type"`
+			Recipient string `json:"recipient"`
+			Code      string `json:"code"`
+			UserID    int64  `json:"user_id"`
+			TTLSec    int    `json:"ttl_sec"`
+		}
+
+		payload, err := json.Marshal(resetEvent{
+			Type:      "password_reset",
+			Recipient: login,
+			Code:      code,
+			UserID:    userID,
+			TTLSec:    ttlSec,
+		})
+		if err != nil {
+			return fmt.Errorf("json: marshal event: %w", err)
+		}
+
+		ch, err := conn.Channel()
+		if err != nil {
+			return fmt.Errorf("broker: open channel: %w", err)
+		}
+		defer ch.Close()
+
+		if err := ch.ExchangeDeclare(
+			cfg.RmqExchangeName,
+			cfg.RmqExchangeKind,
+			true, false, false, false, nil,
+		); err != nil {
+			return fmt.Errorf("broker: declare exchange: %w", err)
+		}
+
+		if err := ch.PublishWithContext(ctx,
+			cfg.RmqExchangeName,
+			cfg.RmqQueueMailName,
+			false, false,
+			amqp.Publishing{
+				ContentType: "application/json",
+				Body:        payload,
+			},
+		); err != nil {
+			return fmt.Errorf("broker: publish: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ConfirmPasswordReset verifies the reset code, updates the password, and invalidates all sessions.
+func ConfirmPasswordReset(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	cfg *config.Config,
+	cacheClient *cache.Client,
+	login, code, deviceUID, newPassword string,
+) error {
+	login = strings.TrimSpace(login)
+	code = strings.TrimSpace(code)
+	newPassword = strings.TrimSpace(newPassword)
+
+	if pool == nil {
+		return nil
+	}
+
+	// Find user by login
+	isEmail := strings.Contains(login, "@")
+	var userID int64
+	var findQuery string
+	if isEmail {
+		findQuery = `SELECT id FROM users WHERE LOWER(email) = LOWER($1) LIMIT 1`
+	} else {
+		findQuery = `SELECT id FROM users WHERE phone = $1 LIMIT 1`
+	}
+	if err := pool.QueryRow(ctx, findQuery, login).Scan(&userID); err != nil {
+		return fmt.Errorf("%w: user not found", ErrNotFound)
+	}
+
+	// Find reset code
+	var storedCode string
+	var counter int64
+	var sentTS time.Time
+	err := pool.QueryRow(ctx,
+		`SELECT code, counter, sent_ts FROM confirm_codes
+		 WHERE device_uid=$1 AND recipient=$2 AND auth_type=$3 LIMIT 1`,
+		deviceUID, login, authTypePasswordReset,
+	).Scan(&storedCode, &counter, &sentTS)
+	if err != nil {
+		return ErrInvalidCode
+	}
+
+	// Check TTL
+	ttlSec := cfg.PasswordResetCodeTTLMin * 60
+	if ttlSec > 0 {
+		expiry := sentTS.Add(time.Duration(ttlSec) * time.Second)
+		if time.Now().After(expiry) {
+			return ErrCodeExpired
+		}
+	}
+
+	// Compare code
+	if code != storedCode {
+		// Increment counter
+		_, _ = pool.Exec(ctx,
+			`UPDATE confirm_codes SET counter=counter+1
+			 WHERE device_uid=$1 AND recipient=$2 AND auth_type=$3`,
+			deviceUID, login, authTypePasswordReset,
+		)
+		return ErrInvalidCode
+	}
+
+	// Validate new password
+	if err := validatePassword(newPassword, cfg); err != nil {
+		return fmt.Errorf("%w: %s", ErrWeakPassword, err.Error())
+	}
+
+	// Hash new password
+	saltedPassword := cfg.PasswordSalt + newPassword
+	hash, err := bcrypt.GenerateFromPassword([]byte(saltedPassword), 12)
+	if err != nil {
+		return fmt.Errorf("bcrypt: %w", err)
+	}
+
+	// Update password
+	_, err = pool.Exec(ctx,
+		`UPDATE users SET password=$1, update_date=NOW() WHERE id=$2`,
+		string(hash), userID,
+	)
+	if err != nil {
+		return fmt.Errorf("db: update password: %w", err)
+	}
+
+	// Delete the reset code
+	_, _ = pool.Exec(ctx,
+		`DELETE FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 AND auth_type=$3`,
+		deviceUID, login, authTypePasswordReset,
+	)
+
+	// Invalidate all active sessions for this user
+	// First, collect session tokens for Redis cache invalidation
+	if cacheClient != nil {
+		rows, qErr := pool.Query(ctx,
+			`SELECT token FROM sessions WHERE user_id=$1 AND blocked=false`,
+			userID,
+		)
+		if qErr == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var t string
+				if rows.Scan(&t) == nil {
+					_ = cacheClient.DeleteSession(ctx, t)
+				}
+			}
+		}
+	}
+
+	// Mark all sessions as blocked in DB
+	_, _ = pool.Exec(ctx,
+		`UPDATE sessions SET blocked=true WHERE user_id=$1`,
+		userID,
+	)
+
+	return nil
+}

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -86,7 +86,7 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 	if pool != nil && cfg.RateLimit.Code.TTLSec > 0 {
 		var oldSentTS time.Time
 		err := pool.QueryRow(ctx,
-			`SELECT sent_ts FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 LIMIT 1`,
+			`SELECT sent_ts FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 AND auth_type='verification' LIMIT 1`,
 			deviceUID, recipient,
 		).Scan(&oldSentTS)
 		if err == nil {
@@ -125,9 +125,9 @@ func SendCode(ctx context.Context, pool *pgxpool.Pool, conn *amqp.Connection, cf
 	// UPSERT into confirm_codes
 	if pool != nil {
 		_, upsertErr := pool.Exec(ctx,
-			`INSERT INTO confirm_codes (device_uid, recipient, code, counter, sent_ts)
-			 VALUES ($1, $2, $3, 0, $4)
-			 ON CONFLICT (device_uid, recipient) DO UPDATE
+			`INSERT INTO confirm_codes (device_uid, recipient, code, counter, sent_ts, auth_type)
+			 VALUES ($1, $2, $3, 0, $4, 'verification')
+			 ON CONFLICT (device_uid, recipient, auth_type) DO UPDATE
 			 SET code = EXCLUDED.code, counter = 0, sent_ts = EXCLUDED.sent_ts`,
 			deviceUID, recipient, code, now,
 		)
@@ -246,7 +246,7 @@ func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, cac
 	var sentTS time.Time
 
 	err := pool.QueryRow(ctx,
-		`SELECT code, counter, sent_ts FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 LIMIT 1`,
+		`SELECT code, counter, sent_ts FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 AND auth_type='verification' LIMIT 1`,
 		deviceUID, recipient,
 	).Scan(&storedCode, &counter, &sentTS)
 	if err != nil {
@@ -270,7 +270,7 @@ func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, cac
 	if code != storedCode {
 		// Increment counter
 		_, _ = pool.Exec(ctx,
-			`UPDATE confirm_codes SET counter=counter+1 WHERE device_uid=$1 AND recipient=$2`,
+			`UPDATE confirm_codes SET counter=counter+1 WHERE device_uid=$1 AND recipient=$2 AND auth_type='verification'`,
 			deviceUID, recipient,
 		)
 		return fmt.Errorf("%w: invalid verification code", ErrUnauthorized)
@@ -293,7 +293,7 @@ func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, cac
 	}
 
 	_, err = pool.Exec(ctx,
-		`DELETE FROM confirm_codes WHERE device_uid=$1 AND recipient=$2`,
+		`DELETE FROM confirm_codes WHERE device_uid=$1 AND recipient=$2 AND auth_type='verification'`,
 		deviceUID, recipient,
 	)
 	if err != nil {

--- a/migrations/004_confirm_codes_auth_type.sql
+++ b/migrations/004_confirm_codes_auth_type.sql
@@ -1,0 +1,4 @@
+ALTER TABLE confirm_codes ADD COLUMN IF NOT EXISTS auth_type TEXT NOT NULL DEFAULT 'verification';
+
+DROP INDEX IF EXISTS idx_confirm_codes_device_recipient;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_confirm_codes_device_recipient_type ON confirm_codes (device_uid, recipient, auth_type);

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -91,6 +91,10 @@ func TestMain(m *testing.M) {
 	r.POST("/auth/logout", handler.Logout(pool, testCache))
 	r.POST("/auth/login/verify-2fa", handler.VerifyLogin2FA(pool, cfg))
 
+	// Password reset (public — no auth required)
+	r.POST("/auth/password/reset-request", handler.ResetRequest(pool, nil, cfg, testCache))
+	r.POST("/auth/password/reset-confirm", handler.ResetConfirm(pool, cfg, testCache))
+
 	// Protected routes
 	authRequired := r.Group("/")
 	authRequired.Use(middleware.Auth(pool, testCache))

--- a/tests/integration/password_reset_test.go
+++ b/tests/integration/password_reset_test.go
@@ -1,0 +1,212 @@
+package integration
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// getResetCode reads the password reset code directly from the DB for a given login + device.
+func getResetCode(t *testing.T, login, deviceUID string) string {
+	t.Helper()
+	ctx := context.Background()
+	var code string
+	err := testPool.QueryRow(ctx,
+		`SELECT code FROM confirm_codes WHERE recipient=$1 AND device_uid=$2 AND auth_type='password_reset' LIMIT 1`,
+		login, deviceUID,
+	).Scan(&code)
+	if err != nil {
+		t.Fatalf("getResetCode(%s, %s): %v", login, deviceUID, err)
+	}
+	return code
+}
+
+// TestPasswordReset_HappyPath tests the full flow:
+// request reset → confirm → login with new password.
+func TestPasswordReset_HappyPath(t *testing.T) {
+	truncateTables(t)
+
+	login := "reset-test@example.com" // TestAccount with fixed code 777777
+	password := "OldPass1"
+	newPassword := "NewPass2"
+	deviceUID := "device-reset-happy"
+
+	// Register and verify user
+	regToken := registerUser(t, login, password)
+	verifyUser(t, login, deviceUID, regToken)
+
+	// Step 1: request password reset
+	w := doRequestWithDevice("POST", "/auth/password/reset-request", map[string]string{
+		"login":     login,
+		"device_uid": deviceUID,
+	}, "", deviceUID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reset-request: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Step 2: confirm reset with fixed test code 777777
+	w = doRequestWithDevice("POST", "/auth/password/reset-confirm", map[string]interface{}{
+		"login":        login,
+		"code":         "777777",
+		"device_uid":   deviceUID,
+		"new_password": newPassword,
+	}, "", deviceUID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reset-confirm: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Step 3: login with new password should succeed
+	w = doRequest("POST", "/auth/login", map[string]string{
+		"login":    login,
+		"password": newPassword,
+	}, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("login after reset: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["token"] == nil {
+		t.Error("expected token in login response after reset")
+	}
+
+	// Step 4: old password should no longer work
+	w = doRequest("POST", "/auth/login", map[string]string{
+		"login":    login,
+		"password": password,
+	}, "")
+	if w.Code == http.StatusOK {
+		t.Error("old password should not work after reset")
+	}
+}
+
+// TestPasswordReset_WrongCode tests that a wrong code returns 400 ERR_INVALID_CODE.
+func TestPasswordReset_WrongCode(t *testing.T) {
+	truncateTables(t)
+
+	login := "reset-wrongcode@example.com"
+	password := "OldPass1"
+	deviceUID := "device-reset-wrongcode"
+
+	regToken := registerUser(t, login, password)
+	verifyUser(t, login, deviceUID, regToken)
+
+	// Request reset
+	w := doRequestWithDevice("POST", "/auth/password/reset-request", map[string]string{
+		"login":     login,
+		"device_uid": deviceUID,
+	}, "", deviceUID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reset-request: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Confirm with wrong code
+	w = doRequestWithDevice("POST", "/auth/password/reset-confirm", map[string]interface{}{
+		"login":        login,
+		"code":         "000000",
+		"device_uid":   deviceUID,
+		"new_password": "NewPass2",
+	}, "", deviceUID)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("wrong code: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["code"] != "ERR_INVALID_CODE" {
+		t.Errorf("expected ERR_INVALID_CODE, got %v", body["code"])
+	}
+}
+
+// TestPasswordReset_NonExistentUser tests that reset-request returns 200 for non-existent user (no enumeration).
+func TestPasswordReset_NonExistentUser(t *testing.T) {
+	truncateTables(t)
+
+	w := doRequestWithDevice("POST", "/auth/password/reset-request", map[string]string{
+		"login":     "nobody@nonexistent.example.com",
+		"device_uid": "device-reset-nouser",
+	}, "", "device-reset-nouser")
+	if w.Code != http.StatusOK {
+		t.Fatalf("no-enumeration: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestPasswordReset_WeakPassword tests that a weak new password returns 400 ERR_WEAK_PASSWORD.
+func TestPasswordReset_WeakPassword(t *testing.T) {
+	truncateTables(t)
+
+	login := "reset-test@example.com" // TestAccount with fixed code 777777
+	password := "OldPass1"
+	deviceUID := "device-reset-weak"
+
+	regToken := registerUser(t, login, password)
+	verifyUser(t, login, deviceUID, regToken)
+
+	// Request reset
+	w := doRequestWithDevice("POST", "/auth/password/reset-request", map[string]string{
+		"login":     login,
+		"device_uid": deviceUID,
+	}, "", deviceUID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reset-request: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Confirm with valid code but weak password (too short / no digit)
+	w = doRequestWithDevice("POST", "/auth/password/reset-confirm", map[string]interface{}{
+		"login":        login,
+		"code":         "777777",
+		"device_uid":   deviceUID,
+		"new_password": "abc", // too short, no digit
+	}, "", deviceUID)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("weak password: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(w)
+	if body["code"] != "ERR_WEAK_PASSWORD" {
+		t.Errorf("expected ERR_WEAK_PASSWORD, got %v", body["code"])
+	}
+}
+
+// TestPasswordReset_SessionsInvalidated tests that existing sessions are invalidated after reset.
+func TestPasswordReset_SessionsInvalidated(t *testing.T) {
+	truncateTables(t)
+
+	login := "reset-test@example.com" // TestAccount with fixed code 777777
+	password := "OldPass1"
+	newPassword := "NewPass3"
+	deviceUID := "device-reset-session"
+
+	regToken := registerUser(t, login, password)
+	verifyUser(t, login, deviceUID, regToken)
+
+	// Login to get a session token
+	oldToken := loginUser(t, login, password)
+
+	// Verify /auth/me works with old token
+	w := doRequest("GET", "/auth/me", nil, oldToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("me before reset: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Request password reset
+	w = doRequestWithDevice("POST", "/auth/password/reset-request", map[string]string{
+		"login":     login,
+		"device_uid": deviceUID,
+	}, "", deviceUID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reset-request: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Confirm reset
+	w = doRequestWithDevice("POST", "/auth/password/reset-confirm", map[string]interface{}{
+		"login":        login,
+		"code":         "777777",
+		"device_uid":   deviceUID,
+		"new_password": newPassword,
+	}, "", deviceUID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reset-confirm: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Old token should no longer work
+	w = doRequest("GET", "/auth/me", nil, oldToken)
+	if w.Code == http.StatusOK {
+		t.Error("old session token should be invalidated after password reset")
+	}
+}


### PR DESCRIPTION
## Изменения

- `POST /auth/password/reset-request` — запрос кода сброса (без перечисления пользователей, rate limiting по IP + login)
- `POST /auth/password/reset-confirm` — подтверждение кода + новый пароль + аннулирование всех сессий
- Конфиг: `PasswordResetCodeTTLMin` (default 15), `PasswordResetRateLimitPerHour` (default 3)
- TestAccounts: `reset-test@example.com` / `777777`
- Миграция: `migrations/004_confirm_codes_auth_type.sql`
- Swagger документация

## Тесты
```
TestPasswordReset_HappyPath — PASS
TestPasswordReset_WrongCode — PASS
TestPasswordReset_NonExistentUser — PASS
TestPasswordReset_WeakPassword — PASS
TestPasswordReset_SessionsInvalidated — PASS

Все интеграционные тесты: 24 PASS
```

Closes #39