### PR TITLE
fix: security audit #5 + ARM64 build (#41)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ vendor:
 
 build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BIN_DIR)/$(BIN_FILE) ./cmd/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o $(BIN_DIR)/$(BIN_FILE)-arm64 ./cmd/main.go
 
 test:
 	go test ./...
@@ -50,16 +51,31 @@ swagger:
 	swag init -g cmd/main.go -o docs/
 
 deb: build
-	$(eval DEB_NAME := $(BIN_FILE)_$(VERSION)_amd64)
-	mkdir -p /tmp/$(DEB_NAME)/DEBIAN
-	mkdir -p /tmp/$(DEB_NAME)/usr/bin
-	mkdir -p /tmp/$(DEB_NAME)/etc/systemd/system
-	mkdir -p /tmp/$(DEB_NAME)/etc/auth-service
-	install -m 0755 $(BIN_DIR)/$(BIN_FILE) /tmp/$(DEB_NAME)/usr/bin/$(BIN_FILE)
-	install -m 0644 auth-service.service /tmp/$(DEB_NAME)/etc/systemd/system/auth-service.service
-	install -m 0600 auth-service.example.json /tmp/$(DEB_NAME)/etc/auth-service/config.json
+	$(eval DEB_AMD64 := $(BIN_FILE)_$(VERSION)_amd64)
+	mkdir -p /tmp/$(DEB_AMD64)/DEBIAN
+	chmod 0755 /tmp/$(DEB_AMD64)/DEBIAN
+	mkdir -p /tmp/$(DEB_AMD64)/usr/bin
+	mkdir -p /tmp/$(DEB_AMD64)/etc/systemd/system
+	mkdir -p /tmp/$(DEB_AMD64)/etc/auth-service
+	install -m 0755 $(BIN_DIR)/$(BIN_FILE) /tmp/$(DEB_AMD64)/usr/bin/$(BIN_FILE)
+	install -m 0644 auth-service.service /tmp/$(DEB_AMD64)/etc/systemd/system/auth-service.service
+	install -m 0600 auth-service.example.json /tmp/$(DEB_AMD64)/etc/auth-service/config.json
 	printf 'Package: $(BIN_FILE)\nVersion: $(VERSION)\nArchitecture: amd64\nMaintainer: darkrain\nDescription: auth-service\n' \
-		> /tmp/$(DEB_NAME)/DEBIAN/control
-	dpkg-deb --build /tmp/$(DEB_NAME) $(BIN_DIR)/$(DEB_NAME).deb
-	rm -rf /tmp/$(DEB_NAME)
-	@echo "Built: $(BIN_DIR)/$(DEB_NAME).deb"
+		> /tmp/$(DEB_AMD64)/DEBIAN/control
+	dpkg-deb --build /tmp/$(DEB_AMD64) $(BIN_DIR)/$(DEB_AMD64).deb
+	rm -rf /tmp/$(DEB_AMD64)
+	@echo "Built: $(BIN_DIR)/$(DEB_AMD64).deb"
+	$(eval DEB_ARM64 := $(BIN_FILE)_$(VERSION)_arm64)
+	mkdir -p /tmp/$(DEB_ARM64)/DEBIAN
+	chmod 0755 /tmp/$(DEB_ARM64)/DEBIAN
+	mkdir -p /tmp/$(DEB_ARM64)/usr/bin
+	mkdir -p /tmp/$(DEB_ARM64)/etc/systemd/system
+	mkdir -p /tmp/$(DEB_ARM64)/etc/auth-service
+	install -m 0755 $(BIN_DIR)/$(BIN_FILE)-arm64 /tmp/$(DEB_ARM64)/usr/bin/$(BIN_FILE)
+	install -m 0644 auth-service.service /tmp/$(DEB_ARM64)/etc/systemd/system/auth-service.service
+	install -m 0600 auth-service.example.json /tmp/$(DEB_ARM64)/etc/auth-service/config.json
+	printf 'Package: $(BIN_FILE)\nVersion: $(VERSION)\nArchitecture: arm64\nMaintainer: darkrain\nDescription: auth-service\n' \
+		> /tmp/$(DEB_ARM64)/DEBIAN/control
+	dpkg-deb --build /tmp/$(DEB_ARM64) $(BIN_DIR)/$(DEB_ARM64).deb
+	rm -rf /tmp/$(DEB_ARM64)
+	@echo "Built: $(BIN_DIR)/$(DEB_ARM64).deb"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,7 +38,6 @@ import (
 	"github.com/darkrain/auth-service/internal/middleware"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/redis/go-redis/v9"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
@@ -94,23 +93,16 @@ func main() {
 		db.StartSessionCleanup(ctx, pgPool, log.Default())
 	}
 
-	// Redis
-	rdb := redis.NewClient(&redis.Options{
-		Network: cfg.RedisDatabaseNetwork,
-		Addr:    fmt.Sprintf("%s:%s", cfg.RedisDatabaseHost, cfg.RedisDatabasePort),
-	})
-	defer rdb.Close()
+	cacheClient := cache.NewClient(cfg)
 
 	// Ping Redis in background — don't block startup
 	go func() {
-		if err := rdb.Ping(context.Background()).Err(); err != nil {
+		if err := cacheClient.Ping(context.Background()); err != nil {
 			log.Printf("WARNING: Redis not available: %v", err)
 		} else {
 			log.Println("Redis connected")
 		}
 	}()
-
-	cacheClient := cache.NewClient(cfg)
 
 	// RabbitMQ
 	rmqConn, err := broker.Connect(cfg)
@@ -187,8 +179,16 @@ func main() {
 		handler.VerifyLogin2FA(pgPool, cfg))
 
 	// Password reset (public — no auth required)
-	r.POST("/auth/password/reset-request", handler.ResetRequest(pgPool, rmqConn, cfg, cacheClient))
-	r.POST("/auth/password/reset-confirm", handler.ResetConfirm(pgPool, cfg, cacheClient))
+	r.POST("/auth/password/reset-request",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/password/reset-request",
+			cfg.RateLimit.IP.SendCodeMaxAttempts, cfg.RateLimit.IP.SendCodeWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.ResetRequest(pgPool, rmqConn, cfg, cacheClient))
+	r.POST("/auth/password/reset-confirm",
+		middleware.RateLimit(cacheClient, rmqConn, "/auth/password/reset-confirm",
+			cfg.RateLimit.IP.SendCodeMaxAttempts, cfg.RateLimit.IP.SendCodeWindowSec,
+			cfg.RateLimit.Device.SendCodeMaxAttempts, cfg.RateLimit.Device.SendCodeWindowSec),
+		handler.ResetConfirm(pgPool, cfg, cacheClient))
 
 	// Protected routes (require valid session token)
 	authRequired := r.Group("/")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/darkrain/auth-service
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/gin-gonic/gin v1.12.0

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -35,6 +35,11 @@ func NewClient(cfg *config.Config) *Client {
 	return &Client{rdb: rdb}
 }
 
+// Ping checks the Redis connection.
+func (c *Client) Ping(ctx context.Context) error {
+	return c.rdb.Ping(ctx).Err()
+}
+
 func sessionKey(token string) string {
 	return "session:" + token
 }

--- a/internal/handler/password_reset.go
+++ b/internal/handler/password_reset.go
@@ -99,7 +99,7 @@ func ResetConfirm(pool *pgxpool.Pool, cfg *config.Config, cacheClient *cache.Cli
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):
-				c.JSON(http.StatusNotFound, errResp(CodeUserNotFound, "user not found"))
+				c.JSON(http.StatusBadRequest, errResp(CodeInvalidCode, "invalid reset code"))
 			case errors.Is(err, service.ErrCodeExpired):
 				c.JSON(http.StatusBadRequest, errResp(CodeCodeExpired, "reset code has expired"))
 			case errors.Is(err, service.ErrInvalidCode):

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -266,7 +267,7 @@ func LoginVerify2FA(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config,
 		if cfg.RateLimit.Code.MaxAttempts > 0 && counter >= int64(cfg.RateLimit.Code.MaxAttempts) {
 			return nil, fmt.Errorf("%w: Too many attempts. Request a new code.", ErrTooManyRequests)
 		}
-		if req.Code != storedCode {
+		if subtle.ConstantTimeCompare([]byte(req.Code), []byte(storedCode)) != 1 {
 			_, _ = pool.Exec(ctx,
 				`UPDATE confirm_codes SET counter=counter+1 WHERE device_uid=$1 AND recipient=$2`,
 				req.DeviceUID, req.Login,

--- a/internal/service/password_reset.go
+++ b/internal/service/password_reset.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -234,7 +235,7 @@ func ConfirmPasswordReset(
 	}
 
 	// Compare code
-	if code != storedCode {
+	if subtle.ConstantTimeCompare([]byte(code), []byte(storedCode)) != 1 {
 		// Increment counter
 		_, _ = pool.Exec(ctx,
 			`UPDATE confirm_codes SET counter=counter+1

--- a/internal/service/verification.go
+++ b/internal/service/verification.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -267,7 +268,7 @@ func VerifyCode(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, cac
 	}
 
 	// Compare code
-	if code != storedCode {
+	if subtle.ConstantTimeCompare([]byte(code), []byte(storedCode)) != 1 {
 		// Increment counter
 		_, _ = pool.Exec(ctx,
 			`UPDATE confirm_codes SET counter=counter+1 WHERE device_uid=$1 AND recipient=$2 AND auth_type='verification'`,


### PR DESCRIPTION
## Изменения

- Go 1.26.1 → 1.26.2 (закрывает GO-2026-4870, GO-2026-4866, GO-2026-4946, GO-2026-4947, GO-2026-4865)
- `middleware.RateLimit` на `/auth/password/reset-request` и `/auth/password/reset-confirm`
- `subtle.ConstantTimeCompare` вместо `!=` при сравнении кодов (3 места)
- `reset-confirm`: user not found → 400 `ERR_INVALID_CODE` (устранена частичная user enumeration)
- Убран дублирующий Redis-клиент `rdb` в `main.go`
- `Makefile`: сборка `linux/arm64` + deb пакет arm64

## Тесты
Все интеграционные тесты: PASS (57/57)

Closes #41