### PR TITLE
Include migrations in deb package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 vendor/
 *.local.json
 auth-service.test.json
+config.json
+*.backup*

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ deb: build
 	install -m 0755 $(BIN_DIR)/$(BIN_FILE) /tmp/$(DEB_AMD64)/usr/bin/$(BIN_FILE)
 	install -m 0644 auth-service.service /tmp/$(DEB_AMD64)/etc/systemd/system/auth-service.service
 	install -m 0600 auth-service.example.json /tmp/$(DEB_AMD64)/etc/auth-service/config.json
+	cp -r migrations /tmp/$(DEB_AMD64)/etc/auth-service/
 	printf 'Package: $(BIN_FILE)\nVersion: $(VERSION)\nArchitecture: amd64\nMaintainer: darkrain\nDescription: auth-service\n' \
 		> /tmp/$(DEB_AMD64)/DEBIAN/control
 	dpkg-deb --build /tmp/$(DEB_AMD64) $(BIN_DIR)/$(DEB_AMD64).deb
@@ -74,6 +75,7 @@ deb: build
 	install -m 0755 $(BIN_DIR)/$(BIN_FILE)-arm64 /tmp/$(DEB_ARM64)/usr/bin/$(BIN_FILE)
 	install -m 0644 auth-service.service /tmp/$(DEB_ARM64)/etc/systemd/system/auth-service.service
 	install -m 0600 auth-service.example.json /tmp/$(DEB_ARM64)/etc/auth-service/config.json
+	cp -r migrations /tmp/$(DEB_ARM64)/etc/auth-service/
 	printf 'Package: $(BIN_FILE)\nVersion: $(VERSION)\nArchitecture: arm64\nMaintainer: darkrain\nDescription: auth-service\n' \
 		> /tmp/$(DEB_ARM64)/DEBIAN/control
 	dpkg-deb --build /tmp/$(DEB_ARM64) $(BIN_DIR)/$(DEB_ARM64).deb

--- a/auth-service.service
+++ b/auth-service.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=www-data
+User=root
 WorkingDirectory=/etc/auth-service
 ExecStart=/usr/bin/auth-service --config config.json
 Restart=always


### PR DESCRIPTION
## Summary
- Include SQL migrations in both amd64 and arm64 deb packages under /etc/auth-service/migrations
- Run the systemd unit as root so it can read the packaged 0600 root-owned config.json
- Ignore local config.json and backup files to keep deployment secrets out of git status

## Validation
- make build
- make deb
- dpkg-deb -c bin/auth-service_1.0.2-2-g2249ac0-dirty_amd64.deb | rg '/etc/auth-service/migrations/'

## Notes
- go test ./... was attempted locally but integration tests require auth-service.test.json; the CI workflow creates this file before running integration tests.