### PR TITLE
Разрешить регистрацию роли client

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ make run
 
 This uses `auth-service.example.json` as the config by default.
 
+`AllowedRoles` controls public registration roles. For iamfree webapp registration
+it must include `model`, `manager`, `agency` and `client`. The `client` role is
+used by the topmember registration flow when the webapp URL contains
+`?topmember=true`.
+
 To use a custom config:
 
 ```bash

--- a/auth-service.example.json
+++ b/auth-service.example.json
@@ -30,7 +30,7 @@
   "PostgreSQLSSLMode": "require",
   "SwaggerEnabled": false,
   "TestAccounts": [],
-  "AllowedRoles": ["model", "manager", "agency"],
+  "AllowedRoles": ["model", "manager", "agency", "client"],
   "RateLimit": {
     "IP": {
       "LoginMaxAttempts": 5,


### PR DESCRIPTION
## Что сделано\n- Добавлена роль client в AllowedRoles в example config.\n- README уточняет, что webapp topmember flow использует role=client при ?topmember=true.\n\n## Проверки\n- go test ./internal/... ./cmd/...\n\nСвязано с theGHub1/webapp#36